### PR TITLE
Add newId function to generate a call ID.

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 )
 
 const (
@@ -43,9 +44,9 @@ func (c *Client) Prefix(prefix, URI string) error {
 	return nil
 }
 
-func (c *Client) Call(callID, procURI string, args ...interface{}) error {
+func (c *Client) Call(procURI string, args ...interface{}) error {
 	log.Trace("sending call")
-	msg, err := CreateCall(callID, procURI, args...)
+	msg, err := CreateCall(newId(16), procURI, args...)
 	if err != nil {
 		return fmt.Errorf("turnpike: %s", err)
 	}
@@ -201,4 +202,14 @@ func (c *Client) Connect(server, origin string) error {
 	go c.Send()
 
 	return nil
+}
+
+// newId generates a random string of fixed size.
+func newId(size int) string {
+	const alpha = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz0123456789-_"
+	buf := make([]byte, size)
+	for i := 0; i < size; i++ {
+		buf[i] = alpha[rand.Intn(len(alpha))]
+	}
+	return string(buf)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -67,7 +67,7 @@ func main() {
 			err = c.Prefix(prefix, URI)
 		case turnpike.CALL:
 			args := strings.Split(line, " ")
-			err = c.Call(args[0], args[1], args[2:])
+			err = c.Call(args[0], args[1:])
 		case turnpike.SUBSCRIBE:
 			err = c.Subscribe(line)
 		case turnpike.UNSUBSCRIBE:


### PR DESCRIPTION
See AutobahnPython Clinet implementation for reference:
https://github.com/tavendo/AutobahnPython/blob/master/autobahn/autobahn/util.py#L65
