### PR TITLE
Add documentation for public API

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,15 +13,20 @@ const (
 
 var clientBacklog = 10
 
+// Client represents a WAMP client that handles RPC and pub/sub.
 type Client struct {
-	ws              *websocket.Conn
-	messages        chan string
-	prefixes        PrefixMap
-	SessionId       string
+	// SessionId is a ID of the session in UUID4 format received at the start of the session.
+	SessionId string
+	// ProtocolVersion is the version of the WAMP protocol received at the start of the session.
 	ProtocolVersion int
-	ServerIdent     string
+	// ServerIdent is the server ID (ie "turnpike, autobahn") received at the start of the session.
+	ServerIdent string
+	ws          *websocket.Conn
+	messages    chan string
+	prefixes    PrefixMap
 }
 
+// NewClient creates a new WAMP client.
 func NewClient() *Client {
 	return &Client{
 		messages: make(chan string, clientBacklog),
@@ -29,6 +34,11 @@ func NewClient() *Client {
 	}
 }
 
+// Prefix sets a CURIE prefix at the server for later use when interacting with
+// the server. prefix is the first part of a CURIE (ie "calc") and URI is a full
+// identifier (ie "http://example.com/simple/calc#") that is mapped to the prefix.
+//
+// Ref: http://wamp.ws/spec#prefix_message
 func (c *Client) Prefix(prefix, URI string) error {
 	log.Trace("sending prefix")
 	err := c.prefixes.RegisterPrefix(prefix, URI)
@@ -43,6 +53,10 @@ func (c *Client) Prefix(prefix, URI string) error {
 	return nil
 }
 
+// Call makes a RPC call on the server identified by procURI (in either full URI
+// or CURIE format) with zero or more args.
+//
+// Ref: http://wamp.ws/spec#call_message
 func (c *Client) Call(callID, procURI string, args ...interface{}) error {
 	log.Trace("sending call")
 	msg, err := CreateCall(callID, procURI, args...)
@@ -53,6 +67,10 @@ func (c *Client) Call(callID, procURI string, args ...interface{}) error {
 	return nil
 }
 
+// Subscribe adds a subscription at the server for events with topicURI lasting
+// for the session or until Unsubscribe is called.
+//
+// Ref: http://wamp.ws/spec#subscribe_message
 func (c *Client) Subscribe(topicURI string) error {
 	log.Trace("sending subscribe")
 	msg, err := CreateSubscribe(topicURI)
@@ -63,6 +81,9 @@ func (c *Client) Subscribe(topicURI string) error {
 	return nil
 }
 
+// Unsubscribe removes a previous subscription with topicURI at the server.
+//
+// Ref: http://wamp.ws/spec#unsubscribe_message
 func (c *Client) Unsubscribe(topicURI string) error {
 	log.Trace("sending unsubscribe")
 	msg, err := CreateUnsubscribe(topicURI)
@@ -73,6 +94,13 @@ func (c *Client) Unsubscribe(topicURI string) error {
 	return nil
 }
 
+// Publish publishes an event to the topicURI that gets sent to all subscribers
+// of that topicURI by the server. opts can can be either empty, one boolean
+// that can be used to exclude outself from receiving the event or two lists;
+// the first a list of clients to exclude and the second a list of clients that
+// are eligible to receive the event. Either list can be empty.
+//
+// Ref: http://wamp.ws/spec#publish_message
 func (c *Client) Publish(topicURI string, event interface{}, opts ...interface{}) error {
 	log.Trace("sending publish)")
 	msg, err := CreatePublish(topicURI, event, opts...)
@@ -83,6 +111,8 @@ func (c *Client) Publish(topicURI string, event interface{}, opts ...interface{}
 	return nil
 }
 
+// PublishExcludeMe is a short hand for Publish(tobicURI, event, true) that will
+// not send the event to ourself.
 func (c *Client) PublishExcludeMe(topicURI string, event interface{}) error {
 	return c.Publish(topicURI, event, true)
 }
@@ -184,6 +214,8 @@ func (c *Client) Send() {
 	}
 }
 
+// Connect will connect to server with an optional origin.
+// More details here: http://godoc.org/code.google.com/p/go.net/websocket#Dial
 func (c *Client) Connect(server, origin string) error {
 	log.Trace("connect")
 	var err error

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,18 @@
+package turnpike_test
+
+import (
+	"code.google.com/p/go.net/websocket"
+	"github.com/jcelliott/turnpike"
+	"net/http"
+)
+
+func ExampleNewServer() {
+	s := turnpike.NewServer()
+	ws := websocket.Handler(s.HandleWebsocket)
+
+	http.Handle("/ws", ws)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		panic("ListenAndServe: " + err.Error())
+	}
+}


### PR DESCRIPTION
I though some documentation would be good to have for new users. This is a start. Together with cleaning up the public API as in https://github.com/jcelliott/turnpike/issues/16 it will be a well documented and clean library.
