### PR TITLE
Add server pub/sub handlers

### DIFF
--- a/server.go
+++ b/server.go
@@ -377,7 +377,7 @@ func (t *Server) handleSubscribe(id string, msg subscribeMsg) {
 
 	uri := checkCurie(t.prefixes[id], msg.TopicURI)
 	h := t.getSubHandler(uri)
-	if !h(id, uri) {
+	if h != nil && !h(id, uri) {
 		if debug {
 			log.Printf("turnpike: client %s denied subscription of topic: %s", id, uri)
 		}

--- a/server.go
+++ b/server.go
@@ -67,7 +67,7 @@ type Server struct {
 	subscriptions map[string]listenerMap
 	//           client    prefixes
 	prefixes            map[string]prefixMap
-	rpcHooks            map[string]RPCHandler
+	rpcHandlers         map[string]RPCHandler
 	sessionOpenCallback func(string)
 	subLock             *sync.Mutex
 	websocket.Server
@@ -89,7 +89,7 @@ func NewServer() *Server {
 		clients:       make(map[string]chan string),
 		subscriptions: make(map[string]listenerMap),
 		prefixes:      make(map[string]prefixMap),
-		rpcHooks:      make(map[string]RPCHandler),
+		rpcHandlers:   make(map[string]RPCHandler),
 		subLock:       new(sync.Mutex),
 	}
 	s.Server = websocket.Server{
@@ -124,7 +124,7 @@ func (t *Server) handleCall(id string, msg callMsg) {
 	var out string
 	var err error
 
-	if f, ok := t.rpcHooks[msg.ProcURI]; ok && f != nil {
+	if f, ok := t.rpcHandlers[msg.ProcURI]; ok && f != nil {
 		var res interface{}
 		res, err = f(id, msg.ProcURI, msg.CallArgs...)
 		if err != nil {
@@ -431,13 +431,13 @@ func (t *Server) SetSessionOpenCallback(f func(string)) {
 // RegisterRPC adds a handler for the RPC named uri.
 func (t *Server) RegisterRPC(uri string, f RPCHandler) {
 	if f != nil {
-		t.rpcHooks[uri] = f
+		t.rpcHandlers[uri] = f
 	}
 }
 
 // UnregisterRPC removes a handler for the RPC named uri.
 func (t *Server) UnregisterRPC(uri string) {
-	delete(t.rpcHooks, uri)
+	delete(t.rpcHandlers, uri)
 }
 
 // SendEvent sends an event with topic directly (not via Client.Publish())

--- a/server.go
+++ b/server.go
@@ -414,8 +414,15 @@ func (t *Server) handlePublish(id string, msg publishMsg) {
 	if debug {
 		log.Print("turnpike: handling publish message")
 	}
-	topic := checkCurie(t.prefixes[id], msg.TopicURI)
-	lm, ok := t.subscriptions[topic]
+	uri := checkCurie(t.prefixes[id], msg.TopicURI)
+
+	h := t.getPubHandler(uri)
+	event := msg.Event
+	if h != nil {
+		event = h(uri, event)
+	}
+
+	lm, ok := t.subscriptions[uri]
 	if !ok {
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -400,13 +400,13 @@ func (t *Server) handleUnsubscribe(id string, msg unsubscribeMsg) {
 		log.Print("turnpike: handling unsubscribe message")
 	}
 	t.subLock.Lock()
-	topic := checkCurie(t.prefixes[id], msg.TopicURI)
-	if lm, ok := t.subscriptions[topic]; ok {
+	uri := checkCurie(t.prefixes[id], msg.TopicURI)
+	if lm, ok := t.subscriptions[uri]; ok {
 		lm.remove(id)
 	}
 	t.subLock.Unlock()
 	if debug {
-		log.Printf("turnpike: client %s unsubscribed from topic: %s", id, topic)
+		log.Printf("turnpike: client %s unsubscribed from topic: %s", id, uri)
 	}
 }
 
@@ -420,7 +420,7 @@ func (t *Server) handlePublish(id string, msg publishMsg) {
 		return
 	}
 
-	out, err := createEvent(topic, msg.Event)
+	out, err := createEvent(uri, event)
 	if err != nil {
 		if debug {
 			log.Printf("turnpike: error creating event message: %s", err)

--- a/server.go
+++ b/server.go
@@ -47,7 +47,7 @@ type Server struct {
 // all optional arguments to the RPC call. The return can be of any type that
 // can be marshaled to JSON, or a error (preferably RPCError but any error works.)
 // NOTE: this may be broken in v2 if multiple-return is implemented
-type RPCHandler func(callID string, topicURI string, args ...interface{}) (interface{}, error)
+type RPCHandler func(clientID string, topicURI string, args ...interface{}) (interface{}, error)
 
 // RPCError represents a call error and is the recommended way to return an
 // error from a RPC handler.

--- a/server_test.go
+++ b/server_test.go
@@ -162,3 +162,86 @@ func TestServer_SubHandlerDeny(t *testing.T) {
 	c.Publish("event:test", "test")
 	<-time.After(time.Second)
 }
+
+func TestServer_RegisterPubHandler(t *testing.T) {
+	s := NewServer()
+	pubCh := make(chan bool)
+	s.RegisterPubHandler("event:test", func(topicURI string, event interface{}) interface{} {
+		pubCh <- true
+		return event
+	})
+
+	http.Handle("/ws_s5", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8105", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8105/ws_s5", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	// c.Subscribe("event:test", func(uri string, event interface{}) {})
+	c.Publish("event:test", "test")
+
+	select {
+	case <-pubCh:
+		return
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+}
+
+func TestServer_PubHandlerChange(t *testing.T) {
+	s := NewServer()
+	s.RegisterPubHandler("event:test", func(topicURI string, event interface{}) interface{} {
+		return event.(string) + "2"
+	})
+
+	http.Handle("/ws_s6", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8106", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8106/ws_s6", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	eventCh := make(chan bool)
+	c.Subscribe("event:test", func(uri string, event interface{}) {
+		if event != "test2" {
+			t.Fail()
+		}
+		eventCh <- true
+	})
+
+	c.Publish("event:test", "test")
+
+	select {
+	case <-eventCh:
+		return
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -5,7 +5,6 @@
 package turnpike
 
 import (
-	"errors"
 	"net/http"
 	"runtime"
 	"testing"
@@ -15,12 +14,12 @@ import (
 func TestServer_SubNoHandler(t *testing.T) {
 	s := NewServer()
 
-	http.Handle("/ws1", s.Handler)
+	http.Handle("/ws_s1", s.Handler)
 	// TODO: needs better way of running multiple listen and serve.
 	// Currently there is no way of closing the listener. A cusom server and
 	// handler will work but requires more work. TBD.
 	go func() {
-		err := http.ListenAndServe(":8001", nil)
+		err := http.ListenAndServe(":8101", nil)
 		if err != nil {
 			t.Fatal("ListenAndServe: " + err.Error())
 		}
@@ -30,7 +29,7 @@ func TestServer_SubNoHandler(t *testing.T) {
 	runtime.Gosched()
 
 	c := NewClient()
-	err := c.Connect("ws://127.0.0.1:8001/ws1", "http://localhost/")
+	err := c.Connect("ws://127.0.0.1:8101/ws_s1", "http://localhost/")
 	if err != nil {
 		t.Fatal("error connecting: " + err.Error())
 	}
@@ -59,12 +58,12 @@ func TestServer_RegisterSubHandler(t *testing.T) {
 		return true
 	})
 
-	http.Handle("/ws2", s.Handler)
+	http.Handle("/ws_s2", s.Handler)
 	// TODO: needs better way of running multiple listen and serve.
 	// Currently there is no way of closing the listener. A cusom server and
 	// handler will work but requires more work. TBD.
 	go func() {
-		err := http.ListenAndServe(":8002", nil)
+		err := http.ListenAndServe(":8102", nil)
 		if err != nil {
 			t.Fatal("ListenAndServe: " + err.Error())
 		}
@@ -74,7 +73,7 @@ func TestServer_RegisterSubHandler(t *testing.T) {
 	runtime.Gosched()
 
 	c := NewClient()
-	err := c.Connect("ws://127.0.0.1:8002/ws2", "http://localhost/")
+	err := c.Connect("ws://127.0.0.1:8102/ws_s2", "http://localhost/")
 	if err != nil {
 		t.Fatal("error connecting: " + err.Error())
 	}
@@ -95,12 +94,12 @@ func TestServer_SubHandlerAccept(t *testing.T) {
 		return true
 	})
 
-	http.Handle("/ws3", s.Handler)
+	http.Handle("/ws_s3", s.Handler)
 	// TODO: needs better way of running multiple listen and serve.
 	// Currently there is no way of closing the listener. A cusom server and
 	// handler will work but requires more work. TBD.
 	go func() {
-		err := http.ListenAndServe(":8003", nil)
+		err := http.ListenAndServe(":8103", nil)
 		if err != nil {
 			t.Fatal("ListenAndServe: " + err.Error())
 		}
@@ -110,7 +109,7 @@ func TestServer_SubHandlerAccept(t *testing.T) {
 	runtime.Gosched()
 
 	c := NewClient()
-	err := c.Connect("ws://127.0.0.1:8003/ws3", "http://localhost/")
+	err := c.Connect("ws://127.0.0.1:8103/ws_s3", "http://localhost/")
 	if err != nil {
 		t.Fatal("error connecting: " + err.Error())
 	}
@@ -136,12 +135,12 @@ func TestServer_SubHandlerDeny(t *testing.T) {
 		return false
 	})
 
-	http.Handle("/ws4", s.Handler)
+	http.Handle("/ws_s4", s.Handler)
 	// TODO: needs better way of running multiple listen and serve.
 	// Currently there is no way of closing the listener. A cusom server and
 	// handler will work but requires more work. TBD.
 	go func() {
-		err := http.ListenAndServe(":8004", nil)
+		err := http.ListenAndServe(":8104", nil)
 		if err != nil {
 			t.Fatal("ListenAndServe: " + err.Error())
 		}
@@ -151,7 +150,7 @@ func TestServer_SubHandlerDeny(t *testing.T) {
 	runtime.Gosched()
 
 	c := NewClient()
-	err := c.Connect("ws://127.0.0.1:8004/ws4", "http://localhost/")
+	err := c.Connect("ws://127.0.0.1:8104/ws_s4", "http://localhost/")
 	if err != nil {
 		t.Fatal("error connecting: " + err.Error())
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2013 Joshua Elliott
+// Released under the MIT License
+// http://opensource.org/licenses/MIT
+
+package turnpike
+
+import (
+	"errors"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestServer_SubNoHandler(t *testing.T) {
+	s := NewServer()
+
+	http.Handle("/ws1", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8001", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8001/ws1", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	eventCh := make(chan bool)
+	c.Subscribe("event:test", func(uri string, event interface{}) {
+		eventCh <- true
+	})
+
+	c.Publish("event:test", "test")
+
+	select {
+	case <-eventCh:
+		return
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+
+}
+
+func TestServer_RegisterSubHandler(t *testing.T) {
+	s := NewServer()
+	subCh := make(chan bool)
+	s.RegisterSubHandler("event:test", func(clientID, topicURI string) bool {
+		subCh <- true
+		return true
+	})
+
+	http.Handle("/ws2", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8002", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8002/ws2", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	c.Subscribe("event:test", func(uri string, event interface{}) {})
+
+	select {
+	case <-subCh:
+		return
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+}
+
+func TestServer_SubHandlerAccept(t *testing.T) {
+	s := NewServer()
+	s.RegisterSubHandler("event:test", func(clientID, topicURI string) bool {
+		return true
+	})
+
+	http.Handle("/ws3", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8003", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8003/ws3", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	eventCh := make(chan bool)
+	c.Subscribe("event:test", func(uri string, event interface{}) {
+		eventCh <- true
+	})
+
+	c.Publish("event:test", "test")
+
+	select {
+	case <-eventCh:
+		return
+	case <-time.After(time.Second):
+		t.Fail()
+	}
+}
+
+func TestServer_SubHandlerDeny(t *testing.T) {
+	s := NewServer()
+	s.RegisterSubHandler("event:test", func(clientID, topicURI string) bool {
+		return false
+	})
+
+	http.Handle("/ws4", s.Handler)
+	// TODO: needs better way of running multiple listen and serve.
+	// Currently there is no way of closing the listener. A cusom server and
+	// handler will work but requires more work. TBD.
+	go func() {
+		err := http.ListenAndServe(":8004", nil)
+		if err != nil {
+			t.Fatal("ListenAndServe: " + err.Error())
+		}
+	}()
+
+	// Let the server goroutine start.
+	runtime.Gosched()
+
+	c := NewClient()
+	err := c.Connect("ws://127.0.0.1:8004/ws4", "http://localhost/")
+	if err != nil {
+		t.Fatal("error connecting: " + err.Error())
+	}
+
+	c.Subscribe("event:test", func(uri string, event interface{}) {
+		t.Fail()
+	})
+
+	c.Publish("event:test", "test")
+	<-time.After(time.Second)
+}


### PR DESCRIPTION
This implements two handlers that can be set on the server; one that is called when a client subscribes to a topic and one that is called on publishes to a topic. The URI that is used to register both cases can be a partial URI ("http://api.example.com/event") or a full URI ("http://api.example.com/event#test") in which case the most descriptive URI is called. This way general catch-all handlers can be added and also more specific handlers to certain topics.

In the subscription handler a client can be allowed or denied to subscribe by returning true or false, this will come in handy when implementing the CRA authentication where permissions control which topics can be subscribed by which client.

The publish handler can be used to modify the event by returning a new version, or cancel it altogether by returning nil.

I added basic tests, but more testing on the partial URL matching needs to be done.
