### PR TITLE
MessagePack serializer and change to gorilla/websocket

### DIFF
--- a/wampv2/broker.go
+++ b/wampv2/broker.go
@@ -1,7 +1,7 @@
 package wampv2
 
 func spliceSubscribers(subs []Subscriber, i int) []Subscriber {
-	if i == len(subs) - 1 {
+	if i == len(subs)-1 {
 		return subs[:i]
 	}
 	return append(subs[:i], subs[i+1:]...)
@@ -45,13 +45,13 @@ type Broker interface {
 
 // A super simple broker that matches URIs to Subscribers.
 type BasicBroker struct {
-	routes map[URI]map[ID]Subscriber
+	routes        map[URI]map[ID]Subscriber
 	subscriptions map[ID]URI
 }
 
 func NewBasicBroker() *BasicBroker {
 	return &BasicBroker{
-		routes: make(map[URI]map[ID]Subscriber),
+		routes:        make(map[URI]map[ID]Subscriber),
 		subscriptions: make(map[ID]URI),
 	}
 }
@@ -60,7 +60,7 @@ func (br *BasicBroker) Publish(pub Publisher, msg *Publish) {
 	pubId := NewID()
 	evtTemplate := Event{
 		Publication: pubId,
-		Arguments: msg.Arguments,
+		Arguments:   msg.Arguments,
 		ArgumentsKw: msg.ArgumentsKw,
 	}
 	for id, sub := range br.routes[msg.Topic] {
@@ -90,9 +90,9 @@ func (br *BasicBroker) Unsubscribe(sub Subscriber, msg *Unsubscribe) {
 	topic, ok := br.subscriptions[msg.Subscription]
 	if !ok {
 		err := &Error{
-			Type: msg.MessageType(),
+			Type:    msg.MessageType(),
 			Request: msg.Request,
-			Error: WAMP_ERROR_NO_SUCH_SUBSCRIPTION,
+			Error:   WAMP_ERROR_NO_SUCH_SUBSCRIPTION,
 		}
 		sub.SendError(err)
 		return
@@ -100,16 +100,16 @@ func (br *BasicBroker) Unsubscribe(sub Subscriber, msg *Unsubscribe) {
 
 	if r, ok := br.routes[topic]; !ok {
 		err := &Error{
-			Type: msg.MessageType(),
+			Type:    msg.MessageType(),
 			Request: msg.Request,
-			Error: URI("wamp.error.internal_error"),
+			Error:   URI("wamp.error.internal_error"),
 		}
 		sub.SendError(err)
 	} else if _, ok := r[msg.Subscription]; !ok {
 		err := &Error{
-			Type: msg.MessageType(),
+			Type:    msg.MessageType(),
 			Request: msg.Request,
-			Error: URI("wamp.error.internal_error"),
+			Error:   URI("wamp.error.internal_error"),
 		}
 		sub.SendError(err)
 	} else {

--- a/wampv2/realm.go
+++ b/wampv2/realm.go
@@ -9,6 +9,7 @@ type Realm interface {
 
 type BasicRealm struct {
 }
+
 func NewBasicRealm() *BasicRealm {
 	return &BasicRealm{}
 }

--- a/wampv2/serialize.go
+++ b/wampv2/serialize.go
@@ -4,11 +4,89 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"github.com/ugorji/go/codec"
 )
 
 type Serializer interface {
 	Serialize(Message) ([]byte, error)
 	Deserialize([]byte) (Message, error)
+}
+
+type MessagePackSerializer struct {
+}
+
+func (s *MessagePackSerializer) Serialize(msg Message) ([]byte, error) {
+	arr := []interface{}{int(msg.MessageType())}
+	val := reflect.ValueOf(msg)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	for i := 0; i < val.NumField(); i++ {
+		arr = append(arr, val.Field(i).Interface())
+	}
+
+	var b []byte
+	return b, codec.NewEncoderBytes(&b, new(codec.MsgpackHandle)).Encode(arr)
+}
+
+func (s *MessagePackSerializer) Deserialize(data []byte) (Message, error) {
+	var arr []interface{}
+	if err := codec.NewDecoderBytes(data, new(codec.MsgpackHandle)).Decode(&arr); err != nil {
+		return nil, err
+	} else if len(arr) == 0 {
+		return nil, fmt.Errorf("Invalid message")
+	}
+
+	var msgType MessageType
+	if typ, ok := arr[0].(int64); ok {
+		msgType = MessageType(typ)
+	} else {
+		return nil, fmt.Errorf("Unsupported message format")
+	}
+
+	msg := msgType.New()
+	if msg == nil {
+		return nil, fmt.Errorf("Unsupported message type")
+	}
+	val := reflect.ValueOf(msg)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	for i := 0; i < val.NumField() && i < len(arr)-1; i++ {
+		f := val.Field(i)
+		if arr[i+1] == nil {
+			continue
+		}
+		arg := reflect.ValueOf(arr[i+1])
+		if arg.Kind() == reflect.Ptr {
+			arg = arg.Elem()
+		}
+		if !arg.Type().ConvertibleTo(f.Type()) {
+			// special-case map maps
+			if arg.Type().Kind() == reflect.Map && f.Type().Kind() == reflect.Map {
+				keyType := f.Type().Key()
+				valType := f.Type().Elem()
+				m := reflect.MakeMap(f.Type())
+				for _, k := range arg.MapKeys() {
+					if !k.Type().ConvertibleTo(keyType) {
+						return nil, fmt.Errorf("Message format error: %dth field not recognizable")
+					}
+					v := arg.MapIndex(k)
+					if !v.Type().ConvertibleTo(valType) {
+						return nil, fmt.Errorf("Message format error: %dth field not recognizable")
+					}
+					m.SetMapIndex(k.Convert(keyType), v.Convert(valType))
+				}
+				f.Set(m)
+			} else {
+				return nil, fmt.Errorf("Message format error: %dth field not recognizable", i+1)
+			}
+		} else {
+			f.Set(arg.Convert(f.Type()))
+		}
+	}
+	return msg, nil
 }
 
 type JSONSerializer struct {
@@ -25,6 +103,7 @@ func (s *JSONSerializer) Serialize(msg Message) ([]byte, error) {
 	}
 	return json.Marshal(arr)
 }
+
 func (s *JSONSerializer) Deserialize(data []byte) (Message, error) {
 	var arr []interface{}
 	if err := json.Unmarshal(data, &arr); err != nil {

--- a/wampv2/websocket.go
+++ b/wampv2/websocket.go
@@ -5,9 +5,9 @@ import (
 )
 
 type websocketEndpoint struct {
-	conn *websocket.Conn
-	serializer Serializer
-	messages chan Message
+	conn        *websocket.Conn
+	serializer  Serializer
+	messages    chan Message
 	payloadType int
 }
 
@@ -28,10 +28,10 @@ func newWebsocketClient(url, protocol, origin string, serializer Serializer, pay
 		return nil, err
 	}
 	ep := &websocketEndpoint{
-			conn: conn,
-			messages: make(chan Message, 10),
-			serializer: serializer,
-			payloadType: payloadType,
+		conn:        conn,
+		messages:    make(chan Message, 10),
+		serializer:  serializer,
+		payloadType: payloadType,
 	}
 	go func() {
 		for {

--- a/wampv2/websocket.go
+++ b/wampv2/websocket.go
@@ -12,7 +12,11 @@ type websocketEndpoint struct {
 }
 
 func NewJSONWebsocketClient(url, origin string) (Endpoint, error) {
-	return newWebsocketClient(url, jsonWebsocketProtocol, origin, &JSONSerializer{}, websocket.TextMessage)
+	return newWebsocketClient(url, jsonWebsocketProtocol, origin, new(JSONSerializer), websocket.TextMessage)
+}
+
+func NewMessagePackWebsocketClient(url, origin string) (Endpoint, error) {
+	return newWebsocketClient(url, msgpackWebsocketProtocol, origin, new(MessagePackSerializer), websocket.BinaryMessage)
 }
 
 func newWebsocketClient(url, protocol, origin string, serializer Serializer, payloadType int) (Endpoint, error) {

--- a/wampv2/websocket_server.go
+++ b/wampv2/websocket_server.go
@@ -82,12 +82,12 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 		//       gorilla/websocket will reject the conncetion
 		//       if the subprotocol isn't registered
 		switch conn.Subprotocol() {
-		case "wamp.2.json":
+		case jsonWebsocketProtocol:
 			serializer = new(JSONSerializer)
 			payloadType = websocket.TextMessage
-		case "wamp.2.msgpack":
-			// TODO: implement msgpack
-			fallthrough
+		case msgpackWebsocketProtocol:
+			serializer = new(MessagePackSerializer)
+			payloadType = websocket.BinaryMessage
 		default:
 			conn.Close()
 			return

--- a/wampv2/websocket_server.go
+++ b/wampv2/websocket_server.go
@@ -8,29 +8,31 @@ import (
 )
 
 const (
-	jsonWebsocketProtocol = "wamp.2.json"
+	jsonWebsocketProtocol    = "wamp.2.json"
 	msgpackWebsocketProtocol = "wamp.2.msgpack"
 )
 
 type invalidPayload byte
+
 func (e invalidPayload) Error() string {
 	return fmt.Sprintf("Invalid payloadType: %d", e)
 }
 
 type protocolExists string
+
 func (e protocolExists) Error() string {
 	return "This protocol has already been registered: " + string(e)
 }
 
 type protocol struct {
 	payloadType int
-	serializer Serializer
+	serializer  Serializer
 }
 
 // WebsocketServer handles websocket connections.
 type WebsocketServer struct {
 	upgrader *websocket.Upgrader
-	router Router
+	router   Router
 
 	protocols map[string]protocol
 
@@ -42,7 +44,7 @@ type WebsocketServer struct {
 
 func NewWebsocketServer(r Router) *WebsocketServer {
 	s := &WebsocketServer{
-		router: r,
+		router:    r,
 		protocols: make(map[string]protocol),
 	}
 
@@ -95,9 +97,9 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 	}
 
 	ep := websocketEndpoint{
-		conn: conn,
-		serializer: serializer,
-		messages: make(chan Message, 10),
+		conn:        conn,
+		serializer:  serializer,
+		messages:    make(chan Message, 10),
 		payloadType: payloadType,
 	}
 	go func() {

--- a/wampv2/websocket_server.go
+++ b/wampv2/websocket_server.go
@@ -1,9 +1,10 @@
 package wampv2
 
 import (
-	"code.google.com/p/go.net/websocket"
 	"fmt"
 	"net/http"
+
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -22,13 +23,13 @@ func (e protocolExists) Error() string {
 }
 
 type protocol struct {
-	payloadType byte
+	payloadType int
 	serializer Serializer
 }
 
 // WebsocketServer handles websocket connections.
 type WebsocketServer struct {
-	server websocket.Server
+	upgrader *websocket.Upgrader
 	router Router
 
 	protocols map[string]protocol
@@ -45,61 +46,52 @@ func NewWebsocketServer(r Router) *WebsocketServer {
 		protocols: make(map[string]protocol),
 	}
 
-	s.server = websocket.Server{
-		Handshake: s.handshake,
-		Handler:   websocket.Handler(s.handleWebsocket),
-	}
+	s.upgrader = &websocket.Upgrader{}
 	return s
 }
 
-func (s *WebsocketServer) RegisterProtocol(proto string, payloadType byte, serializer Serializer) error {
-	if payloadType != websocket.TextFrame && payloadType != websocket.BinaryFrame {
+func (s *WebsocketServer) RegisterProtocol(proto string, payloadType int, serializer Serializer) error {
+	if payloadType != websocket.TextMessage && payloadType != websocket.BinaryMessage {
 		return invalidPayload(payloadType)
 	}
 	if _, ok := s.protocols[proto]; ok {
 		return protocolExists(proto)
 	}
 	s.protocols[proto] = protocol{payloadType, serializer}
+	s.upgrader.Subprotocols = append(s.upgrader.Subprotocols, proto)
 	return nil
 }
 
 func (s *WebsocketServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.server.ServeHTTP(w, r)
-}
-
-func (s *WebsocketServer) handshake(config *websocket.Config, req *http.Request) error {
-	for _, protocol := range config.Protocol {
-		if _, ok := s.protocols[protocol]; ok {
-			config.Protocol = []string{protocol}
-			return nil
-		}
-		if protocol == jsonWebsocketProtocol || protocol == msgpackWebsocketProtocol {
-			config.Protocol = []string{protocol}
-			return nil
-		}
+	// TODO: subprotocol?
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		fmt.Println("Error:", err)
 	}
-	return websocket.ErrBadWebSocketProtocol
+	s.handleWebsocket(conn)
 }
 
 func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 	var serializer Serializer
-	var payloadType byte
-	for _, proto := range conn.Config().Protocol {
-		if protocol, ok := s.protocols[proto]; ok {
-			serializer = protocol.serializer
-			payloadType = protocol.payloadType
-			break
-		} else if proto == "wamp.2.json" {
+	var payloadType int
+	if proto, ok := s.protocols[conn.Subprotocol()]; ok {
+		serializer = proto.serializer
+		payloadType = proto.payloadType
+	} else {
+		// TODO: this will not currently ever be hit because
+		//       gorilla/websocket will reject the conncetion
+		//       if the subprotocol isn't registered
+		switch conn.Subprotocol() {
+		case "wamp.2.json":
 			serializer = new(JSONSerializer)
-			payloadType = websocket.TextFrame
-			break
-		} else if proto == "wamp.2.msgpack" {
+			payloadType = websocket.TextMessage
+		case "wamp.2.msgpack":
 			// TODO: implement msgpack
+			fallthrough
+		default:
+			conn.Close()
+			return
 		}
-	}
-	if serializer == nil {
-		conn.Close()
-		return
 	}
 
 	ep := websocketEndpoint{
@@ -108,10 +100,22 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 		messages: make(chan Message, 10),
 		payloadType: payloadType,
 	}
-	if payloadType == websocket.TextFrame {
-		go ep.receiveTextFrames()
-	} else if payloadType == websocket.BinaryFrame {
-		go ep.receiveBinaryFrames()
-	}
+	go func() {
+		for {
+			// TODO: use conn.NextMessage() and stream
+			// TODO: do something different based on binary/text frames
+			if _, b, err := conn.ReadMessage(); err != nil {
+				conn.Close()
+				break
+			} else {
+				msg, err := serializer.Deserialize(b)
+				if err != nil {
+					// TODO: handle error
+				} else {
+					ep.messages <- msg
+				}
+			}
+		}
+	}()
 	s.router.Accept(&ep)
 }

--- a/wampv2/websocket_test.go
+++ b/wampv2/websocket_test.go
@@ -6,12 +6,15 @@ import (
 	"net/http"
 	"io"
 	"fmt"
+
+	"github.com/gorilla/websocket"
 )
 
 func newWebsocketServer(t *testing.T) (int, Router, io.Closer) {
 	r := NewBasicRouter()
 	r.RegisterRealm(test_realm, NewBasicRealm())
 	s := NewWebsocketServer(r)
+	s.RegisterProtocol("wamp.2.json", websocket.TextMessage, new(JSONSerializer))
 	server := &http.Server{
 		Handler: s,
 	}

--- a/wampv2/websocket_test.go
+++ b/wampv2/websocket_test.go
@@ -1,11 +1,11 @@
 package wampv2
 
 import (
-	"testing"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
-	"io"
-	"fmt"
+	"testing"
 
 	"github.com/gorilla/websocket"
 )


### PR DESCRIPTION
[gorilla's websocket library](https://github.com/gorilla/websocket) seems nicer than the one in go.net, mostly because:
- easier to differentiate between binary and text frames
- works with autobahn test suite
- seems more actively maintained

The `msgpack` support is kind of gross, and I had to do some hackery to get an unmarshal working, and there are probably bugs with other message formats since only the HELLO message is tested. The current test passes, so there's that.

After writing this, I feel that the `Serializer` interface should be changed to be streaming instead. I'll open another issue so that can be discussed elsewhere.
