### PR TITLE
Added BinaryData type with a custom JSON marshal/unmarshal

### DIFF
--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,6 +1,10 @@
 package turnpike
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -36,25 +40,47 @@ func TestJSONDeserialize(t *testing.T) {
 }
 
 func TestApplySlice(t *testing.T) {
-    const msgType = PUBLISH
+	const msgType = PUBLISH
 
-    pubArgs := []string{"hello", "world"}
-    Convey("Deserializing into a message with a slice", t, func () {
-        args := []interface{}{msgType, 123, make(map[string]interface{}), "some.valid.topic", pubArgs}
-        msg, err := apply(msgType, args)
-        Convey("Should not error", func () {
-            So(err, ShouldBeNil)
-        })
+	pubArgs := []string{"hello", "world"}
+	Convey("Deserializing into a message with a slice", t, func() {
+		args := []interface{}{msgType, 123, make(map[string]interface{}), "some.valid.topic", pubArgs}
+		msg, err := apply(msgType, args)
+		Convey("Should not error", func() {
+			So(err, ShouldBeNil)
+		})
 
-        pubMsg, ok := msg.(*Publish)
-        Convey("The message returned should be a publish message", func () {
-            So(ok, ShouldBeTrue)
-        })
+		pubMsg, ok := msg.(*Publish)
+		Convey("The message returned should be a publish message", func() {
+			So(ok, ShouldBeTrue)
+		})
 
-        Convey("The message received should have the correct arguments", func () {
-            So(len(pubMsg.Arguments), ShouldEqual, 2)
-            So(pubMsg.Arguments[0], ShouldEqual, pubArgs[0])
-            So(pubMsg.Arguments[1], ShouldEqual, pubArgs[1])
-        })
-    })
+		Convey("The message received should have the correct arguments", func() {
+			So(len(pubMsg.Arguments), ShouldEqual, 2)
+			So(pubMsg.Arguments[0], ShouldEqual, pubArgs[0])
+			So(pubMsg.Arguments[1], ShouldEqual, pubArgs[1])
+		})
+	})
+}
+
+func TestBinaryData(t *testing.T) {
+	from := []byte("hello")
+
+	arr, err := json.Marshal(BinaryData(from))
+	if err != nil {
+		t.Error("Error marshalling BinaryData:", err.Error())
+	}
+
+	exp := fmt.Sprintf(`"\u0000%s"`, base64.StdEncoding.EncodeToString(from))
+	if !bytes.Equal([]byte(exp), arr) {
+		t.Errorf("%s != %s", string(arr), exp)
+	}
+
+	var b BinaryData
+	err = json.Unmarshal(arr, &b)
+	if err != nil {
+		t.Errorf("Error unmarshalling marshalled BinaryData:", err)
+	} else if !bytes.Equal([]byte(b), from) {
+		t.Errorf("%s != %s", string(b), string(from))
+	}
 }


### PR DESCRIPTION
- marshals/unmarshals according to the spec:
  https://github.com/tavendo/WAMP/blob/master/spec/basic.md#binary-conversion-of-json-strings
- issue #49 

This doesn't do any magic, so users will have to use this type in their structs if they want to be spec-compliant. We can perhaps add in a magic function to do this dynamically.
