### PR TITLE
Omit empty args/kwargs

### DIFF
--- a/message.go
+++ b/message.go
@@ -246,8 +246,8 @@ type Error struct {
 	Request     ID
 	Details     map[string]interface{}
 	Error       URI
-	Arguments   []interface{}
-	ArgumentsKw map[string]interface{}
+	Arguments   []interface{}          `wamp:"omitempty"`
+	ArgumentsKw map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Error) MessageType() MessageType {
@@ -261,8 +261,8 @@ type Publish struct {
 	Request     ID
 	Options     map[string]interface{}
 	Topic       URI
-	Arguments   []interface{}
-	ArgumentsKw map[string]interface{}
+	Arguments   []interface{}          `wamp:"omitempty"`
+	ArgumentsKw map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Publish) MessageType() MessageType {
@@ -327,8 +327,8 @@ type Event struct {
 	Subscription ID
 	Publication  ID
 	Details      map[string]interface{}
-	Arguments    []interface{}
-	ArgumentsKw  map[string]interface{}
+	Arguments    []interface{}          `wamp:"omitempty"`
+	ArgumentsKw  map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Event) MessageType() MessageType {
@@ -342,8 +342,8 @@ type Call struct {
 	Request     ID
 	Options     map[string]interface{}
 	Procedure   URI
-	Arguments   []interface{}
-	ArgumentsKw map[string]interface{}
+	Arguments   []interface{}          `wamp:"omitempty"`
+	ArgumentsKw map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Call) MessageType() MessageType {
@@ -356,8 +356,8 @@ func (msg *Call) MessageType() MessageType {
 type Result struct {
 	Request     ID
 	Details     map[string]interface{}
-	Arguments   []interface{}
-	ArgumentsKw map[string]interface{}
+	Arguments   []interface{}          `wamp:"omitempty"`
+	ArgumentsKw map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Result) MessageType() MessageType {
@@ -411,8 +411,8 @@ type Invocation struct {
 	Request      ID
 	Registration ID
 	Details      map[string]interface{}
-	Arguments    []interface{}
-	ArgumentsKw  map[string]interface{}
+	Arguments    []interface{}          `wamp:"omitempty"`
+	ArgumentsKw  map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Invocation) MessageType() MessageType {
@@ -425,8 +425,8 @@ func (msg *Invocation) MessageType() MessageType {
 type Yield struct {
 	Request     ID
 	Options     map[string]interface{}
-	Arguments   []interface{}
-	ArgumentsKw map[string]interface{}
+	Arguments   []interface{}          `wamp:"omitempty"`
+	ArgumentsKw map[string]interface{} `wamp:"omitempty"`
 }
 
 func (msg *Yield) MessageType() MessageType {

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -84,3 +84,31 @@ func TestBinaryData(t *testing.T) {
 		t.Errorf("%s != %s", string(b), string(from))
 	}
 }
+
+func TestToList(t *testing.T) {
+	type test struct {
+		args   []interface{}
+		kwArgs map[string]interface{}
+		omit   int
+		msg    string
+	}
+	tests := []test{
+		{[]interface{}{1}, map[string]interface{}{"a": nil}, 0, "default case"},
+		{nil, map[string]interface{}{"a": nil}, 0, "nil args, non-empty kwArgs"},
+		{[]interface{}{}, map[string]interface{}{"a": nil}, 0, "empty args, non-empty kwArgs"},
+		{[]interface{}{1}, nil, 1, "non-empty args, nil kwArgs"},
+		{[]interface{}{1}, make(map[string]interface{}), 1, "non-empty args, empty kwArgs"},
+		{[]interface{}{}, make(map[string]interface{}), 2, "empty args, empty kwArgs"},
+		{nil, nil, 2, "nil args, nil kwArgs"},
+	}
+
+	for _, tst := range tests {
+		msg := &Event{0, 0, nil, tst.args, tst.kwArgs}
+		// +1 to account for the message type
+		numField := reflect.ValueOf(msg).Elem().NumField() + 1
+		exp := numField - tst.omit
+		if l := len(toList(msg)); l != exp {
+			t.Errorf("Incorrect number of fields: %d != %d: %s", l, exp, tst.msg)
+		}
+	}
+}


### PR DESCRIPTION
- resolves #44 

This does not turn a nil slice -> `[]` if kwargs is set. I don't know if WAMP allows args to be `null`, so this is a potential issue.

If this is a requirement for closing this issue, let me know and I'll update this PR.
