### PR TITLE
Add the ability for the client to leave a realm

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,6 +174,10 @@ func formatUnknownMap(m map[string]interface{}) string {
 	return s
 }
 
+func (c *Client) LeaveRealm() {
+	c.Send(goodbyeClient)
+}
+
 func (c *Client) Close() {
 	c.Send(goodbyeClient)
 	c.Peer.Close()


### PR DESCRIPTION
This allows a client to reconnect to a different realm without disconnect from the websocket entirely
