### PR TITLE
b/f: Result: autobahn.js expects the details object to be non-null

### DIFF
--- a/dealer.go
+++ b/dealer.go
@@ -127,6 +127,7 @@ func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
 			// return the result to the caller
 			caller.Send(&Result{
 				Request:     callID,
+				Details:     map[string]interface{}{},
 				Arguments:   msg.Arguments,
 				ArgumentsKw: msg.ArgumentsKw,
 			})

--- a/dealer.go
+++ b/dealer.go
@@ -98,6 +98,7 @@ func (d *defaultDealer) Call(caller Sender, msg *Call) {
 			rproc.Endpoint.Send(&Invocation{
 				Request:      invocationID,
 				Registration: reg,
+				Details: map[string]interface{}{},
 				Arguments:    msg.Arguments,
 				ArgumentsKw:  msg.ArgumentsKw,
 			})


### PR DESCRIPTION
According to the WAMP specification the RESULT message send by the dealer should have the following format:

[RESULT, CALL.Request|id, Details|dict]

i.e. the Details dict should be non-null. Autobahn.js relies on this.
