### PR TITLE
Add Client.Unsubscribe and Client.Unregister

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -1,24 +1,27 @@
 package turnpike
 
 import (
-	"testing"
-
+	"fmt"
 	. "github.com/smartystreets/goconvey/convey"
+	"testing"
 )
 
 type TestSender struct {
 	received Message
 }
 
-func (s *TestSender) Send(msg Message) error { s.received = msg; return nil }
+func (s *TestSender) Send(msg Message) error  { s.received = msg; return nil }
+func (s *TestSender) Close() error            { return fmt.Errorf("Not implemented") }
+func (s *TestSender) Receive() <-chan Message { return nil }
 
 func TestSubscribe(t *testing.T) {
 	Convey("Subscribing to a topic", t, func() {
 		broker := NewDefaultBroker().(*defaultBroker)
 		subscriber := &TestSender{}
+		subscriberSession := Session{Peer: subscriber, Id: 0}
 		testTopic := URI("turnpike.test.topic")
 		msg := &Subscribe{Request: 123, Topic: testTopic}
-		broker.Subscribe(subscriber, msg)
+		broker.Subscribe(subscriberSession, msg)
 
 		Convey("The subscriber should have received a SUBSCRIBED message", func() {
 			sub := subscriber.received.(*Subscribed).Subscription
@@ -39,14 +42,15 @@ func TestSubscribe(t *testing.T) {
 func TestUnsubscribe(t *testing.T) {
 	broker := NewDefaultBroker().(*defaultBroker)
 	subscriber := &TestSender{}
+	subscriberSession := Session{Peer: subscriber, Id: 0}
 	testTopic := URI("turnpike.test.topic")
 	msg := &Subscribe{Request: 123, Topic: testTopic}
-	broker.Subscribe(subscriber, msg)
+	broker.Subscribe(subscriberSession, msg)
 	sub := subscriber.received.(*Subscribed).Subscription
 
 	Convey("Unsubscribing from a topic", t, func() {
 		msg := &Unsubscribe{Request: 124, Subscription: sub}
-		broker.Unsubscribe(subscriber, msg)
+		broker.Unsubscribe(subscriberSession, msg)
 
 		Convey("The peer should have received an UNSUBSCRIBED message", func() {
 			unsub := subscriber.received.(*Unsubscribed).Request

--- a/client.go
+++ b/client.go
@@ -237,6 +237,12 @@ func (c *Client) Receive() {
 		case *Subscribed:
 			c.notifyListener(msg, msg.Request)
 
+		case *Unsubscribed:
+			c.notifyListener(msg, msg.Request)
+
+		case *Unregistered:
+			c.notifyListener(msg, msg.Request)
+
 		case *Result:
 			c.notifyListener(msg, msg.Request)
 
@@ -368,7 +374,7 @@ func (c *Client) Unsubscribe(topic string) error {
 	if err := c.Send(sub); err != nil {
 		return err
 	}
-	// wait to receive SUBSCRIBED message
+	// wait to receive UNSUBSCRIBED message
 	msg, err := c.waitOnListener(id)
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -46,9 +46,19 @@ type Client struct {
 	ReceiveTimeout time.Duration
 	// roles          int
 	listeners    map[ID]chan Message
-	events       map[ID]EventHandler
-	procedures   map[ID]MethodHandler
+	events       map[ID]*eventDesc
+	procedures   map[ID]*procedureDesc
 	requestCount uint
+}
+
+type procedureDesc struct {
+	name    string
+	handler MethodHandler
+}
+
+type eventDesc struct {
+	topic   string
+	handler EventHandler
 }
 
 // Creates a new websocket client.
@@ -67,8 +77,8 @@ func NewClient(p Peer) *Client {
 		ReceiveTimeout: 5 * time.Second,
 		// roles:          roles,
 		listeners:    make(map[ID]chan Message),
-		events:       make(map[ID]EventHandler),
-		procedures:   make(map[ID]MethodHandler),
+		events:       make(map[ID]*eventDesc),
+		procedures:   make(map[ID]*procedureDesc),
 		requestCount: 0,
 	}
 	return c
@@ -212,8 +222,8 @@ func (c *Client) Receive() {
 		switch msg := msg.(type) {
 
 		case *Event:
-			if fn, ok := c.events[msg.Subscription]; ok {
-				go fn(msg.Arguments, msg.ArgumentsKw)
+			if event, ok := c.events[msg.Subscription]; ok {
+				go event.handler(msg.Arguments, msg.ArgumentsKw)
 			} else {
 				log.Println("no handler registered for subscription:", msg.Subscription)
 			}
@@ -250,9 +260,9 @@ func (c *Client) notifyListener(msg Message, requestId ID) {
 }
 
 func (c *Client) handleInvocation(msg *Invocation) {
-	if fn, ok := c.procedures[msg.Registration]; ok {
+	if proc, ok := c.procedures[msg.Registration]; ok {
 		go func() {
-			result := fn(msg.Arguments, msg.ArgumentsKw)
+			result := proc.handler(msg.Arguments, msg.ArgumentsKw)
 
 			var tosend Message
 			tosend = &Yield{
@@ -328,8 +338,46 @@ func (c *Client) Subscribe(topic string, fn EventHandler) error {
 		return fmt.Errorf(formatUnexpectedMessage(msg, SUBSCRIBED))
 	} else {
 		// register the event handler with this subscription
-		c.events[subscribed.Subscription] = fn
+		c.events[subscribed.Subscription] = &eventDesc{topic, fn}
 	}
+	return nil
+}
+
+// Unsubscribe removes the registered EventHandler from the topic.
+func (c *Client) Unsubscribe(topic string) error {
+	var (
+		subscriptionID ID
+		found          bool
+	)
+	for id, desc := range c.events {
+		if desc.topic == topic {
+			subscriptionID = id
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("Event %s is not registered with this client.", topic)
+	}
+
+	id := c.nextID()
+	c.registerListener(id)
+	sub := &Unsubscribe{
+		Request:      id,
+		Subscription: subscriptionID,
+	}
+	if err := c.Send(sub); err != nil {
+		return err
+	}
+	// wait to receive SUBSCRIBED message
+	msg, err := c.waitOnListener(id)
+	if err != nil {
+		return err
+	} else if e, ok := msg.(*Error); ok {
+		return fmt.Errorf("error unsubscribing to topic '%v': %v", topic, e.Error)
+	} else if _, ok := msg.(*Unsubscribed); !ok {
+		return fmt.Errorf(formatUnexpectedMessage(msg, UNSUBSCRIBED))
+	}
+	delete(c.events, subscriptionID)
 	return nil
 }
 
@@ -359,8 +407,47 @@ func (c *Client) Register(procedure string, fn MethodHandler) error {
 		return fmt.Errorf(formatUnexpectedMessage(msg, REGISTERED))
 	} else {
 		// register the event handler with this registration
-		c.procedures[registered.Registration] = fn
+		c.procedures[registered.Registration] = &procedureDesc{procedure, fn}
 	}
+	return nil
+}
+
+// Unregister removes a procedure with the router
+func (c *Client) Unregister(procedure string) error {
+	var (
+		procedureID ID
+		found       bool
+	)
+	for id, p := range c.procedures {
+		if p.name == procedure {
+			procedureID = id
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("Procedure %s is not registered with this client.", procedure)
+	}
+	id := c.nextID()
+	c.registerListener(id)
+	unregister := &Unregister{
+		Request:      id,
+		Registration: procedureID,
+	}
+	if err := c.Send(unregister); err != nil {
+		return err
+	}
+
+	// wait to receive UNREGISTERED message
+	msg, err := c.waitOnListener(id)
+	if err != nil {
+		return err
+	} else if e, ok := msg.(*Error); ok {
+		return fmt.Errorf("error unregister to procedure '%v': %v", procedure, e.Error)
+	} else if _, ok := msg.(*Unregistered); !ok {
+		return fmt.Errorf(formatUnexpectedMessage(msg, UNREGISTERED))
+	}
+	// register the event handler with this unregistration
+	delete(c.procedures, procedureID)
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -62,6 +62,24 @@ func (t *testPeer) Send(msg Message) error {
 				ArgumentsKw: make(map[string]interface{}),
 			}
 		}
+	case *Unregister:
+		// Only allow methods name "mymethod" (4567) to be unregistered
+		if msg.Registration == 4567 {
+			args := make([]interface{}, 0)
+			args = append(args, 1234)
+
+			t.messages <- &Unregistered{
+				Request: msg.Request,
+			}
+		} else {
+			t.messages <- &Error{
+				Type:        UNREGISTER,
+				Request:     msg.Request,
+				Error:       WAMP_ERROR_INVALID_URI,
+				Arguments:   make([]interface{}, 0),
+				ArgumentsKw: make(map[string]interface{}),
+			}
+		}
 
 	case *Yield:
 		// Transform the yield into a result, and send it back to the client.
@@ -184,22 +202,47 @@ func TestRemoteCall(t *testing.T) {
 			})
 		})
 
+		Convey("The callee unregisters an invalid method", func() {
+			err := callee.Unregister("invalidmethod")
+			Convey("And expects an error", func() {
+				So(err, ShouldNotBeNil)
+			})
+		})
+
 		Convey("The callee registers a valid method", func() {
 			handler := func(args []interface{}, kwargs map[string]interface{}) *CallResult {
 				return &CallResult{Args: []interface{}{args[0].(int) * 2}}
 			}
-			err := callee.Register("mymethod", handler)
+			methodName := "mymethod"
+			err := callee.Register(methodName, handler)
 
 			Convey("And expects no error", func() {
 				So(err, ShouldBeNil)
 
 				Convey("The caller calls the callee's remote method", func() {
 					callArgs := []interface{}{5100}
-					result, err := caller.Call("mymethod", callArgs, make(map[string]interface{}))
+					result, err := caller.Call(methodName, callArgs, make(map[string]interface{}))
 
 					Convey("And succeeds at multiplying the number by 2", func() {
 						So(err, ShouldBeNil)
 						So(result.(*Result).Arguments[0], ShouldEqual, 10200)
+					})
+				})
+			})
+
+			Convey("And unregisters the method", func() {
+				err := callee.Unregister(methodName)
+				Convey("And expects no error", func() {
+					So(err, ShouldBeNil)
+				})
+
+				Convey("Calling the unregistered procedure", func() {
+					callArgs := []interface{}{5100}
+					result, err := caller.Call(methodName, callArgs, make(map[string]interface{}))
+
+					Convey("Should result in an error", func() {
+						So(err, ShouldNotBeNil)
+						So(result, ShouldBeNil)
 					})
 				})
 			})

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -10,9 +10,10 @@ func TestRegister(t *testing.T) {
 	Convey("Registering a procedure", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
 		callee := &TestSender{}
+		calleeSession := Session{Peer: callee, Id: 0}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		dealer.Register(calleeSession, msg)
 
 		Convey("The callee should have received a REGISTERED message", func() {
 			reg := callee.received.(*Registered).Registration
@@ -31,7 +32,7 @@ func TestRegister(t *testing.T) {
 
 		Convey("The same procedure cannot be registered more than once", func() {
 			msg := &Register{Request: 321, Procedure: testProcedure}
-			dealer.Register(callee, msg)
+			dealer.Register(calleeSession, msg)
 			So(callee.received, ShouldHaveSameTypeAs, &Error{})
 		})
 	})
@@ -40,14 +41,15 @@ func TestRegister(t *testing.T) {
 func TestUnregister(t *testing.T) {
 	dealer := NewDefaultDealer().(*defaultDealer)
 	callee := &TestSender{}
+	calleeSession := Session{Peer: callee, Id: 0}
 	testProcedure := URI("turnpike.test.endpoint")
 	msg := &Register{Request: 123, Procedure: testProcedure}
-	dealer.Register(callee, msg)
+	dealer.Register(calleeSession, msg)
 	reg := callee.received.(*Registered).Registration
 
 	Convey("Unregistering a procedure", t, func() {
 		msg := &Unregister{Request: 124, Registration: reg}
-		dealer.Unregister(callee, msg)
+		dealer.Unregister(calleeSession, msg)
 
 		Convey("The callee should have received an UNREGISTERED message", func() {
 			unreg := callee.received.(*Unregistered).Request
@@ -67,14 +69,16 @@ func TestCall(t *testing.T) {
 	Convey("With a procedure registered", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
 		callee := &TestSender{}
+		calleeSession := Session{Peer: callee, Id: 0}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		dealer.Register(calleeSession, msg)
 		caller := &TestSender{}
+		callerSession := Session{Peer: caller, Id: 1}
 
 		Convey("Calling an invalid procedure", func() {
 			msg := &Call{Request: 124, Procedure: URI("turnpike.test.bad")}
-			dealer.Call(caller, msg)
+			dealer.Call(callerSession, msg)
 
 			Convey("The caller should have received an ERROR message", func() {
 				err := caller.received.(*Error).Error

--- a/router.go
+++ b/router.go
@@ -110,21 +110,21 @@ func (r *defaultRouter) handleSession(sess Session, realmURI URI) {
 
 		// Broker messages
 		case *Publish:
-			realm.Broker.Publish(sess.Peer, msg)
+			realm.Broker.Publish(sess, msg)
 		case *Subscribe:
-			realm.Broker.Subscribe(sess.Peer, msg)
+			realm.Broker.Subscribe(sess, msg)
 		case *Unsubscribe:
-			realm.Broker.Unsubscribe(sess.Peer, msg)
+			realm.Broker.Unsubscribe(sess, msg)
 
 		// Dealer messages
 		case *Register:
-			realm.Dealer.Register(sess.Peer, msg)
+			realm.Dealer.Register(sess, msg)
 		case *Unregister:
-			realm.Dealer.Unregister(sess.Peer, msg)
+			realm.Dealer.Unregister(sess, msg)
 		case *Call:
-			realm.Dealer.Call(sess.Peer, msg)
+			realm.Dealer.Call(sess, msg)
 		case *Yield:
-			realm.Dealer.Yield(sess.Peer, msg)
+			realm.Dealer.Yield(sess, msg)
 
 		default:
 			log.Println("Unhandled message:", msg.MessageType())


### PR DESCRIPTION
I expanded Client.events and procedures to store the topic/procedure name. To avoid the requirement to know the ID of a subscription or procedure to call Unsubscribe/Unregister.

So far I didn't write any test code. I will look into it later.
