### PR TITLE
Implement Authorizer and Interceptor

### DIFF
--- a/authorizer.go
+++ b/authorizer.go
@@ -1,0 +1,17 @@
+package turnpike
+
+type Authorizer interface {
+	IsAuthorized(msg Message, details map[string]interface{}) (bool, error)
+}
+
+// DefaultAuthorizer always returns authorized.
+type defaultAuthorizer struct {
+}
+
+func NewDefaultAuthorizer() *defaultAuthorizer {
+	return &defaultAuthorizer{}
+}
+
+func (da *defaultAuthorizer) IsAuthorized(msg Message, details map[string]interface{}) (bool, error) {
+	return true, nil
+}

--- a/interceptor.go
+++ b/interceptor.go
@@ -1,0 +1,16 @@
+package turnpike
+
+type Interceptor interface {
+	Modify(msg *Message, details map[string]interface{})
+}
+
+// DefaultInterceptor does nothing :)
+type defaultInterceptor struct {
+}
+
+func NewDefaultInterceptor() *defaultInterceptor {
+	return &defaultInterceptor{}
+}
+
+func (di *defaultInterceptor) Modify(msg *Message, details map[string]interface{}) {
+}

--- a/realm.go
+++ b/realm.go
@@ -12,6 +12,8 @@ type Realm struct {
 	_ string
 	Broker
 	Dealer
+	Authorizer
+	Interceptor
 	CRAuthenticators map[string]CRAuthenticator
 	Authenticators   map[string]Authenticator
 	// DefaultAuth      func(details map[string]interface{}) (map[string]interface{}, error)

--- a/router.go
+++ b/router.go
@@ -83,11 +83,17 @@ func (r *defaultRouter) RegisterRealm(uri URI, realm Realm) error {
 	if realm.Dealer == nil {
 		realm.Dealer = NewDefaultDealer()
 	}
+	if realm.Authorizer == nil {
+		realm.Authorizer = NewDefaultAuthorizer()
+	}
+	if realm.Interceptor == nil {
+		realm.Interceptor = NewDefaultInterceptor()
+	}
 	r.realms[uri] = realm
 	return nil
 }
 
-func (r *defaultRouter) handleSession(sess Session, realmURI URI) {
+func (r *defaultRouter) handleSession(sess Session, realmURI URI, details map[string]interface{}) {
 	defer sess.Close()
 
 	c := sess.Receive()
@@ -111,6 +117,20 @@ func (r *defaultRouter) handleSession(sess Session, realmURI URI) {
 		}
 
 		log.Printf("[%v] %s: %+v", sess.Id, msg.MessageType(), msg)
+		if isAuthz, err := realm.Authorizer.IsAuthorized(msg, details); !isAuthz {
+			if err != nil {
+				log.Println(sess.Id, msg.MessageType(), err.Error())
+			} else {
+				log.Println(sess.Id, msg.MessageType(), WAMP_ERROR_AUTHORIZATION_FAILED)
+			}
+			sess.Send(&Error{
+				Type:  msg.MessageType(),
+				Error: WAMP_ERROR_AUTHORIZATION_FAILED,
+			})
+			continue
+		}
+
+		realm.Interceptor.Modify(&msg, details)
 
 		switch msg := msg.(type) {
 		case *Goodbye:
@@ -207,7 +227,7 @@ func (r *defaultRouter) Accept(client Peer) error {
 			for _, callback := range r.sessionOpenCallbacks {
 				go callback(uint(sess.Id), string(hello.Realm))
 			}
-			go r.handleSession(sess, hello.Realm)
+			go r.handleSession(sess, hello.Realm, welcome.Details)
 		}
 	}
 
@@ -222,7 +242,7 @@ func (r *defaultRouter) GetLocalPeer(realm URI) (Peer, error) {
 	sess := Session{Peer: peerA, Id: NewID(), kill: make(chan URI, 1)}
 	log.Println("Established internal session:", sess.Id)
 	r.clients[realm] = append(r.clients[realm], sess)
-	go r.handleSession(sess, realm)
+	go r.handleSession(sess, realm, make(map[string]interface{}))
 	return peerB, nil
 }
 


### PR DESCRIPTION
This adds an <code>Authorizer</code> (related to #80) and an <code>Interceptor</code>.

The <code>Authorizer</code> is used for authorization of the message, where as the <code>Interceptor</code> is used to modify the message if needed (this is useful if the server should inject information based on the Caller/Publisher).  The default implementations just passes through.

Note that I modified <code>handleSession</code> to receive the details from the WELCOME message and pass it down to both, the <code>Authorizer</code> and <code>Interceptor</code>.  Since the WELCOME message is used during Authentication, there is information there about the user that would either not be available or could not be trusted if received in subsequent messages.
