### PR TITLE
Breaking Change - All functions that took a Peer now take a *Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Turnpike [![Build Status](https://drone.io/github.com/jcelliott/turnpike/status.png)](https://drone.io/github.com/jcelliott/turnpike/latest) [![Coverage Status](https://coveralls.io/repos/jcelliott/turnpike/badge.svg?branch=v2)](https://coveralls.io/r/jcelliott/turnpike?branch=v2) [![GoDoc](https://godoc.org/gopkg.in/jcelliott/turnpike?status.svg)](http://godoc.org/gopkg.in/jcelliott/turnpike.v2)
+Turnpike [![Build Status](https://drone.io/github.com/jcelliott/turnpike/status.png)](https://drone.io/github.com/jcelliott/turnpike/latest) [![Coverage Status](https://coveralls.io/repos/jcelliott/turnpike/badge.svg?branch=v2)](https://coveralls.io/r/jcelliott/turnpike?branch=v2) [![GoDoc](https://godoc.org/gopkg.in/beatgammit/turnpike?status.svg)](http://godoc.org/gopkg.in/beatgammit/turnpike.v2)
 ===
 
 Go implementation of [WAMP](http://wamp.ws/) - The Web Application Messaging Protocol
@@ -18,25 +18,23 @@ basic stand-alone router. The router library can be used to embed a WAMP router
 in another application, or to build a custom router implementation. The client
 library can be used to communicate with any WAMP router.
 
-This version of Turnpike supports WAMP v2. For WAMP v1 support see the [v1 branch](https://github.com/jcelliott/turnpike/tree/v1).
-
 Status
 ---
 
 Turnpike v2 is still under development, but is getting close to a stable
 release. If you have any feedback or suggestions, please
-[open an issue](https://github.com/jcelliott/turnpike/issues/new).
+[open an issue](https://github.com/beatgammit/turnpike/issues/new).
 
 Installation
 ---
 
 Library:
 
-    go get -u gopkg.in/jcelliott/turnpike.v2
+    go get -u gopkg.in/beatgammit/turnpike.v2
 
 Stand-alone router:
 
-    go get -u gopkg.in/jcelliott/turnpike.v2/turnpike
+    go get -u gopkg.in/beatgammit/turnpike.v2/turnpike
 
 Client library usage
 ---
@@ -56,7 +54,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/authorizer.go
+++ b/authorizer.go
@@ -6,7 +6,7 @@ package turnpike
 // Authorize takes the session and the message (request), and returns true if
 // the request is authorized, otherwise false.
 type Authorizer interface {
-	Authorize(session Session, msg Message) (bool, error)
+	Authorize(session *Session, msg Message) (bool, error)
 }
 
 // DefaultAuthorizer always returns authorized.
@@ -18,6 +18,6 @@ func NewDefaultAuthorizer() Authorizer {
 	return &defaultAuthorizer{}
 }
 
-func (da *defaultAuthorizer) Authorize(session Session, msg Message) (bool, error) {
+func (da *defaultAuthorizer) Authorize(session *Session, msg Message) (bool, error) {
 	return true, nil
 }

--- a/broker.go
+++ b/broker.go
@@ -71,13 +71,13 @@ func (br *defaultBroker) Publish(sess *Session, msg *Publish) {
 		event.Subscription = id
 		// don't send event to publisher
 		if sub != pub || !excludePublisher {
-			sub.Send(&event)
+			go sub.Send(&event)
 		}
 	}
 
 	// only send published message if acknowledge is present and set to true
 	if doPub, _ := msg.Options["acknowledge"].(bool); doPub {
-		pub.Send(&Published{Request: msg.Request, Publication: pubID})
+		go pub.Send(&Published{Request: msg.Request, Publication: pubID})
 	}
 }
 
@@ -94,7 +94,7 @@ func (br *defaultBroker) Subscribe(sess *Session, msg *Subscribe) {
 
 	br.subscriptions[id] = msg.Topic
 
-	sess.Peer.Send(&Subscribed{Request: msg.Request, Subscription: id})
+	go sess.Peer.Send(&Subscribed{Request: msg.Request, Subscription: id})
 }
 
 func (br *defaultBroker) Unsubscribe(sess *Session, msg *Unsubscribe) {
@@ -124,5 +124,5 @@ func (br *defaultBroker) Unsubscribe(sess *Session, msg *Unsubscribe) {
 			delete(br.routes, topic)
 		}
 	}
-	sess.Peer.Send(&Unsubscribed{Request: msg.Request})
+	go sess.Peer.Send(&Unsubscribed{Request: msg.Request})
 }

--- a/broker.go
+++ b/broker.go
@@ -39,12 +39,18 @@ func (br *defaultBroker) Publish(sess *Session, msg *Publish) {
 		ArgumentsKw: msg.ArgumentsKw,
 		Details:     make(map[string]interface{}),
 	}
+
+	excludePublisher := true
+	if exclude, ok := msg.Options["exclude_me"].(bool); ok {
+		excludePublisher = exclude
+	}
+
 	for id, sub := range br.routes[msg.Topic] {
 		// shallow-copy the template
 		event := evtTemplate
 		event.Subscription = id
 		// don't send event to publisher
-		if sub != pub {
+		if sub != pub || !excludePublisher {
 			sub.Send(&event)
 		}
 	}

--- a/broker_test.go
+++ b/broker_test.go
@@ -1,6 +1,7 @@
 package turnpike
 
 import (
+	"sync"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -9,11 +10,23 @@ import (
 type TestPeer struct {
 	received Message
 	sent     Message
+
+	sync.RWMutex
 }
 
 func (s *TestPeer) Send(msg Message) error {
+	s.Lock()
+	defer s.Unlock()
+
 	s.received = msg
 	return nil
+}
+
+func (s *TestPeer) getReceived() Message {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.received
 }
 
 // TODO: implement me

--- a/broker_test.go
+++ b/broker_test.go
@@ -53,8 +53,43 @@ func TestSubscribe(t *testing.T) {
 			So(ok, ShouldBeTrue)
 			So(topic, ShouldEqual, testTopic)
 		})
+	})
+}
 
-		// TODO: multiple subscribe requests?
+func TestBrokerNextRequestId(t *testing.T) {
+	Convey("nextRequestId called multiple times", t, func() {
+		broker := NewDefaultBroker().(*defaultBroker)
+		id1 := broker.nextRequestId()
+		id2 := broker.nextRequestId()
+
+		So(id1, ShouldNotEqual, id2)
+	})
+
+	Convey("nextRequestId should roll over", t, func() {
+		broker := NewDefaultBroker().(*defaultBroker)
+		broker.lastRequestId = MAX_REQUEST_ID
+		id := broker.nextRequestId()
+
+		So(id, ShouldEqual, 1)
+	})
+}
+
+func TestMultipleSubscribe(t *testing.T) {
+	const SUBSCRIBERS = 2
+	const TOPIC = URI("turnpike.test.topic")
+
+	Convey("Multiple subscribers to a topic", t, func() {
+		broker := NewDefaultBroker().(*defaultBroker)
+		for i := 0; i < SUBSCRIBERS; i++ {
+			subscriber := &TestPeer{}
+			sess := &Session{Peer: subscriber, Id: NewID()}
+			msg := &Subscribe{Request: sess.NextRequestId(), Topic: TOPIC}
+			broker.Subscribe(sess, msg)
+		}
+
+		Convey("There should be a map entry for each subscriber", func() {
+			So(len(broker.routes[TOPIC]), ShouldEqual, SUBSCRIBERS)
+		})
 	})
 }
 

--- a/client.go
+++ b/client.go
@@ -482,6 +482,15 @@ func (c *Client) Publish(topic string, args []interface{}, kwargs map[string]int
 	})
 }
 
+type RPCError struct {
+	ErrorMessage *Error
+	Procedure    string
+}
+
+func (rpc RPCError) Error() string {
+	return fmt.Sprintf("error calling procedure '%v': %v: %v: %v", rpc.Procedure, rpc.ErrorMessage.Error, rpc.ErrorMessage.Arguments, rpc.ErrorMessage.ArgumentsKw)
+}
+
 // Call calls a procedure given a URI.
 func (c *Client) Call(procedure string, args []interface{}, kwargs map[string]interface{}) (*Result, error) {
 	id := NewID()
@@ -503,7 +512,7 @@ func (c *Client) Call(procedure string, args []interface{}, kwargs map[string]in
 	if err != nil {
 		return nil, err
 	} else if e, ok := msg.(*Error); ok {
-		return nil, fmt.Errorf("error calling procedure '%v': %v", procedure, e.Error)
+		return nil, RPCError{e, procedure}
 	} else if result, ok := msg.(*Result); !ok {
 		return nil, fmt.Errorf(formatUnexpectedMessage(msg, RESULT))
 	} else {

--- a/client.go
+++ b/client.go
@@ -318,6 +318,9 @@ func (c *Client) registerListener(id ID) {
 }
 
 func (c *Client) unregisterListener(id ID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	log.Println("unregister listener:", id)
 	delete(c.listeners, id)
 }

--- a/client.go
+++ b/client.go
@@ -67,7 +67,7 @@ func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Con
 func NewClient(p Peer) *Client {
 	c := &Client{
 		Peer:           p,
-		ReceiveTimeout: 10 * time.Second,
+		ReceiveTimeout: 30 * time.Second,
 		listeners:      make(map[ID]chan Message),
 		events:         make(map[ID]*eventDesc),
 		procedures:     make(map[ID]*procedureDesc),

--- a/data_races.txt
+++ b/data_races.txt
@@ -1,0 +1,44 @@
+...
+3 total assertions
+
+...
+6 total assertions
+
+.
+7 total assertions
+
+.
+8 total assertions
+
+...............
+23 total assertions
+
+.......
+30 total assertions
+
+...
+33 total assertions
+
+..........
+43 total assertions
+
+.....
+48 total assertions
+
+..
+50 total assertions
+
+.....
+55 total assertions
+
+......
+61 total assertions
+
+.....
+66 total assertions
+
+...
+69 total assertions
+
+PASS
+ok  	gopkg.in/beatgammit/turnpike.v2	1.045s

--- a/dealer.go
+++ b/dealer.go
@@ -46,6 +46,8 @@ type defaultDealer struct {
 	// single lock for all invocations; could use RWLock, but in most (all?) cases we want a write lock
 	// TODO: add the lock per session
 	invocationLock sync.Mutex
+
+	sync.RWMutex
 }
 
 // NewDefaultDealer returns the default turnpike dealer implementation
@@ -58,6 +60,9 @@ func NewDefaultDealer() Dealer {
 }
 
 func (d *defaultDealer) Register(sess *Session, msg *Register) {
+	d.Lock()
+	defer d.Unlock()
+
 	if id, ok := d.procedures[msg.Procedure]; ok {
 		log.Println("error: procedure already exists:", msg.Procedure, id)
 		sess.Peer.Send(&Error{
@@ -82,6 +87,9 @@ func (d *defaultDealer) Register(sess *Session, msg *Register) {
 }
 
 func (d *defaultDealer) Unregister(sess *Session, msg *Unregister) {
+	d.Lock()
+	defer d.Unlock()
+
 	if procedure, ok := d.registrations[msg.Registration]; !ok {
 		// the registration doesn't exist
 		log.Println("error: no such registration:", msg.Registration)
@@ -103,6 +111,9 @@ func (d *defaultDealer) Unregister(sess *Session, msg *Unregister) {
 }
 
 func (d *defaultDealer) Call(sess *Session, msg *Call) {
+	d.Lock()
+	defer d.Unlock()
+
 	d.invocationLock.Lock()
 	defer d.invocationLock.Unlock()
 
@@ -136,6 +147,9 @@ func (d *defaultDealer) Call(sess *Session, msg *Call) {
 }
 
 func (d *defaultDealer) Yield(sess *Session, msg *Yield) {
+	d.Lock()
+	defer d.Unlock()
+
 	d.invocationLock.Lock()
 	defer d.invocationLock.Unlock()
 

--- a/dealer.go
+++ b/dealer.go
@@ -3,54 +3,56 @@ package turnpike
 // A Dealer routes and manages RPC calls to callees.
 type Dealer interface {
 	// Register a procedure on an endpoint
-	Register(Sender, *Register)
+	Register(*Session, *Register)
 	// Unregister a procedure on an endpoint
-	Unregister(Sender, *Unregister)
+	Unregister(*Session, *Unregister)
 	// Call a procedure on an endpoint
-	Call(Sender, *Call)
+	Call(*Session, *Call)
 	// Return the result of a procedure call
-	Yield(Sender, *Yield)
+	Yield(*Session, *Yield)
 	// Handle an ERROR message from an invocation
-	Error(Sender, *Error)
+	Error(*Session, *Error)
 	// Remove a callee's registrations
-	RemovePeer(Sender)
+	RemoveSession(*Session)
 }
 
 type remoteProcedure struct {
-	Endpoint  Sender
-	Procedure URI
+	Endpoint     *Session
+	Procedure    URI
+	Registration ID
+}
+
+type rpcRequest struct {
+	caller    *Session
+	requestId ID
 }
 
 type defaultDealer struct {
 	// map registration IDs to procedures
-	procedures map[ID]remoteProcedure
+	procedures map[URI]remoteProcedure
 	// map procedure URIs to registration IDs
 	// TODO: this will eventually need to be `map[URI][]ID` to support
 	// multiple callees for the same procedure
-	registrations map[URI]ID
-	// keep track of call IDs so we can send the response to the caller
-	calls map[ID]Sender
+	registrations map[ID]URI
+
 	// link the invocation ID to the call ID
-	invocations map[ID]ID
-	// keep track of callee's registrations
-	callees map[Sender]map[ID]bool
+	invocations map[*Session]map[ID]rpcRequest
+	// callees map[*Session]map[ID]bool
 }
 
 // NewDefaultDealer returns the default turnpike dealer implementation
 func NewDefaultDealer() Dealer {
 	return &defaultDealer{
-		procedures:    make(map[ID]remoteProcedure),
-		registrations: make(map[URI]ID),
-		calls:         make(map[ID]Sender),
-		invocations:   make(map[ID]ID),
-		callees:       make(map[Sender]map[ID]bool),
+		procedures:    make(map[URI]remoteProcedure),
+		registrations: make(map[ID]URI),
+		invocations:   make(map[*Session]map[ID]rpcRequest),
 	}
 }
 
-func (d *defaultDealer) Register(callee Sender, msg *Register) {
-	if id, ok := d.registrations[msg.Procedure]; ok {
+func (d *defaultDealer) Register(sess *Session, msg *Register) {
+	if id, ok := d.procedures[msg.Procedure]; ok {
 		log.Println("error: procedure already exists:", msg.Procedure, id)
-		callee.Send(&Error{
+		sess.Peer.Send(&Error{
 			Type:    msg.MessageType(),
 			Request: msg.Request,
 			Details: make(map[string]interface{}),
@@ -58,145 +60,120 @@ func (d *defaultDealer) Register(callee Sender, msg *Register) {
 		})
 		return
 	}
-	reg := NewID()
-	d.procedures[reg] = remoteProcedure{callee, msg.Procedure}
-	d.registrations[msg.Procedure] = reg
-	d.addCalleeRegistration(callee, reg)
-	log.Printf("registered procedure %v [%v]", reg, msg.Procedure)
-	callee.Send(&Registered{
+
+	registrationId := NewID()
+	d.procedures[msg.Procedure] = remoteProcedure{sess, msg.Procedure, registrationId}
+	d.registrations[registrationId] = msg.Procedure
+
+	// d.addCalleeRegistration(sess, reg)
+	log.Printf("registered procedure %v [%v]", registrationId, msg.Procedure)
+	sess.Peer.Send(&Registered{
 		Request:      msg.Request,
-		Registration: reg,
+		Registration: registrationId,
 	})
 }
 
-func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
-	if procedure, ok := d.procedures[msg.Registration]; !ok {
+func (d *defaultDealer) Unregister(sess *Session, msg *Unregister) {
+	if procedure, ok := d.registrations[msg.Registration]; !ok {
 		// the registration doesn't exist
 		log.Println("error: no such registration:", msg.Registration)
-		callee.Send(&Error{
+		sess.Peer.Send(&Error{
 			Type:    msg.MessageType(),
 			Request: msg.Request,
 			Details: make(map[string]interface{}),
 			Error:   ErrNoSuchRegistration,
 		})
 	} else {
-		delete(d.registrations, procedure.Procedure)
-		delete(d.procedures, msg.Registration)
-		d.removeCalleeRegistration(callee, msg.Registration)
-		log.Printf("unregistered procedure %v [%v]", procedure.Procedure, msg.Registration)
-		callee.Send(&Unregistered{
+		delete(d.registrations, msg.Registration)
+		delete(d.procedures, procedure)
+		// d.removeCalleeRegistration(sess, msg.Registration)
+		log.Printf("unregistered procedure %v [%v]", procedure, msg.Registration)
+		sess.Peer.Send(&Unregistered{
 			Request: msg.Request,
 		})
 	}
 }
 
-func (d *defaultDealer) Call(caller Sender, msg *Call) {
-	if reg, ok := d.registrations[msg.Procedure]; !ok {
-		caller.Send(&Error{
+func (d *defaultDealer) Call(sess *Session, msg *Call) {
+	if rproc, ok := d.procedures[msg.Procedure]; !ok {
+		sess.Peer.Send(&Error{
 			Type:    msg.MessageType(),
 			Request: msg.Request,
 			Details: make(map[string]interface{}),
 			Error:   ErrNoSuchProcedure,
 		})
 	} else {
-		if rproc, ok := d.procedures[reg]; !ok {
-			// found a registration id, but doesn't match any remote procedure
-			caller.Send(&Error{
-				Type:    msg.MessageType(),
-				Request: msg.Request,
-				Details: make(map[string]interface{}),
-				// TODO: what should this error be?
-				Error: URI("wamp.error.internal_error"),
-			})
-		} else {
-			// everything checks out, make the invocation request
-			// TODO: make the Request ID specific to the caller
-			d.calls[msg.Request] = caller
-			invocationID := NewID()
-			d.invocations[invocationID] = msg.Request
-			rproc.Endpoint.Send(&Invocation{
-				Request:      invocationID,
-				Registration: reg,
-				Details:      map[string]interface{}{},
-				Arguments:    msg.Arguments,
-				ArgumentsKw:  msg.ArgumentsKw,
-			})
-			log.Printf("dispatched CALL %v [%v] to callee as INVOCATION %v",
-				msg.Request, msg.Procedure, invocationID,
-			)
+		// everything checks out, make the invocation request
+		// TODO: make the Request ID specific to the caller
+		// d.calls[msg.Request] = sess
+		invocationID := rproc.Endpoint.NextRequestId()
+		if d.invocations[rproc.Endpoint] == nil {
+			d.invocations[rproc.Endpoint] = make(map[ID]rpcRequest)
 		}
+		d.invocations[rproc.Endpoint][invocationID] = rpcRequest{sess, msg.Request}
+		rproc.Endpoint.Send(&Invocation{
+			Request:      invocationID,
+			Registration: rproc.Registration,
+			Details:      map[string]interface{}{},
+			Arguments:    msg.Arguments,
+			ArgumentsKw:  msg.ArgumentsKw,
+		})
+		log.Printf("dispatched CALL %v [%v] to callee as INVOCATION %v",
+			msg.Request, msg.Procedure, invocationID,
+		)
 	}
 }
 
-func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
-	if callID, ok := d.invocations[msg.Request]; !ok {
+func (d *defaultDealer) Yield(sess *Session, msg *Yield) {
+	if d.invocations[sess] == nil {
+		log.Println("received YIELD message from unknown session:", sess.Id)
+		return
+	}
+	if call, ok := d.invocations[sess][msg.Request]; !ok {
 		// WAMP spec doesn't allow sending an error in response to a YIELD message
 		log.Println("received YIELD message with invalid invocation request ID:", msg.Request)
 	} else {
-		delete(d.invocations, msg.Request)
-		if caller, ok := d.calls[callID]; !ok {
-			// found the invocation id, but doesn't match any call id
-			// WAMP spec doesn't allow sending an error in response to a YIELD message
-			log.Printf("received YIELD message, but unable to match it (%v) to a CALL ID", msg.Request)
-		} else {
-			delete(d.calls, callID)
-			// return the result to the caller
-			caller.Send(&Result{
-				Request:     callID,
-				Details:     map[string]interface{}{},
-				Arguments:   msg.Arguments,
-				ArgumentsKw: msg.ArgumentsKw,
-			})
-			log.Printf("returned YIELD %v to caller as RESULT %v", msg.Request, callID)
-		}
+		// TODO: delete old keys; could do here, but should probably lock the map
+		delete(d.invocations[sess], msg.Request)
+		// return the result to the caller
+		call.caller.Send(&Result{
+			Request:     call.requestId,
+			Details:     map[string]interface{}{},
+			Arguments:   msg.Arguments,
+			ArgumentsKw: msg.ArgumentsKw,
+		})
+		log.Printf("returned YIELD %v to caller as RESULT %v", msg.Request, call.requestId)
 	}
 }
 
-func (d *defaultDealer) Error(peer Sender, msg *Error) {
-	if callID, ok := d.invocations[msg.Request]; !ok {
-		log.Println("received ERROR (INVOCATION) message with invalid invocation request ID:", msg.Request)
-	} else {
-		delete(d.invocations, msg.Request)
-		if caller, ok := d.calls[callID]; !ok {
-			log.Printf("received ERROR (INVOCATION) message, but unable to match it (%v) to a CALL ID", msg.Request)
-		} else {
-			delete(d.calls, callID)
-			// return an error to the caller
-			caller.Send(&Error{
-				Type:        CALL,
-				Request:     callID,
-				Details:     make(map[string]interface{}),
-				Arguments:   msg.Arguments,
-				ArgumentsKw: msg.ArgumentsKw,
-			})
-			log.Printf("returned ERROR %v to caller as ERROR %v", msg.Request, callID)
-		}
-	}
-}
-
-func (d *defaultDealer) RemovePeer(callee Sender) {
-	for reg := range d.callees[callee] {
-		if procedure, ok := d.procedures[reg]; ok {
-			delete(d.registrations, procedure.Procedure)
-			delete(d.procedures, reg)
-		}
-		d.removeCalleeRegistration(callee, reg)
-	}
-}
-
-func (d *defaultDealer) addCalleeRegistration(callee Sender, reg ID) {
-	if _, ok := d.callees[callee]; !ok {
-		d.callees[callee] = make(map[ID]bool)
-	}
-	d.callees[callee][reg] = true
-}
-
-func (d *defaultDealer) removeCalleeRegistration(callee Sender, reg ID) {
-	if _, ok := d.callees[callee]; !ok {
+func (d *defaultDealer) Error(sess *Session, msg *Error) {
+	if d.invocations[sess] == nil {
+		log.Println("received YIELD message from unknown session:", sess.Id)
 		return
 	}
-	delete(d.callees[callee], reg)
-	if len(d.callees[callee]) == 0 {
-		delete(d.callees, callee)
+	if call, ok := d.invocations[sess][msg.Request]; !ok {
+		log.Println("received ERROR (INVOCATION) message with invalid invocation request ID:", msg.Request)
+	} else {
+		delete(d.invocations[sess], msg.Request)
+		// return an error to the caller
+		call.caller.Peer.Send(&Error{
+			Type:        CALL,
+			Request:     call.requestId,
+			Details:     make(map[string]interface{}),
+			Arguments:   msg.Arguments,
+			ArgumentsKw: msg.ArgumentsKw,
+		})
+		log.Printf("returned ERROR %v to caller as ERROR %v", msg.Request, call.requestId)
+	}
+}
+
+func (d *defaultDealer) RemoveSession(sess *Session) {
+	// TODO: this is low hanging fruit for optimization
+	// TODO: potential data race here, should lock the map
+	for _, rproc := range d.procedures {
+		if rproc.Endpoint == sess {
+			delete(d.registrations, rproc.Registration)
+			delete(d.procedures, rproc.Procedure)
+		}
 	}
 }

--- a/dealer.go
+++ b/dealer.go
@@ -210,8 +210,10 @@ func (d *defaultDealer) Error(sess *Session, msg *Error) {
 }
 
 func (d *defaultDealer) RemoveSession(sess *Session) {
+	d.Lock()
+	defer d.Unlock()
+
 	// TODO: this is low hanging fruit for optimization
-	// TODO: potential data race here, should lock the map
 	for _, rproc := range d.procedures {
 		if rproc.Endpoint == sess {
 			delete(d.registrations, rproc.Registration)

--- a/dealer.go
+++ b/dealer.go
@@ -182,6 +182,7 @@ func (d *defaultDealer) Error(sess *Session, msg *Error) {
 		go call.caller.Peer.Send(&Error{
 			Type:        CALL,
 			Request:     call.requestId,
+			Error:       msg.Error,
 			Details:     make(map[string]interface{}),
 			Arguments:   msg.Arguments,
 			ArgumentsKw: msg.ArgumentsKw,

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -9,10 +9,11 @@ import (
 func TestRegister(t *testing.T) {
 	Convey("Registering a procedure", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
 
 		Convey("The callee should have received a REGISTERED message", func() {
 			reg := callee.received.(*Registered).Registration
@@ -21,17 +22,17 @@ func TestRegister(t *testing.T) {
 
 		Convey("The dealer should have the endpoint registered", func() {
 			reg := callee.received.(*Registered).Registration
-			reg2, ok := dealer.registrations[testProcedure]
+			proc, ok := dealer.procedures[testProcedure]
 			So(ok, ShouldBeTrue)
-			So(reg, ShouldEqual, reg2)
-			proc, ok := dealer.procedures[reg]
+			So(reg, ShouldEqual, proc.Registration)
+			procedure, ok := dealer.registrations[reg]
 			So(ok, ShouldBeTrue)
-			So(proc.Procedure, ShouldEqual, testProcedure)
+			So(procedure, ShouldEqual, testProcedure)
 		})
 
 		Convey("The same procedure cannot be registered more than once", func() {
 			msg := &Register{Request: 321, Procedure: testProcedure}
-			dealer.Register(callee, msg)
+			dealer.Register(sess, msg)
 			err := callee.received.(*Error)
 			So(err.Error, ShouldEqual, ErrProcedureAlreadyExists)
 			So(err.Details, ShouldNotBeNil)
@@ -41,15 +42,16 @@ func TestRegister(t *testing.T) {
 
 func TestUnregister(t *testing.T) {
 	dealer := NewDefaultDealer().(*defaultDealer)
-	callee := &TestSender{}
+	callee := &TestPeer{}
 	testProcedure := URI("turnpike.test.endpoint")
 	msg := &Register{Request: 123, Procedure: testProcedure}
-	dealer.Register(callee, msg)
+	sess := &Session{Peer: callee}
+	dealer.Register(sess, msg)
 	reg := callee.received.(*Registered).Registration
 
 	Convey("Unregistering a procedure", t, func() {
 		msg := &Unregister{Request: 124, Registration: reg}
-		dealer.Unregister(callee, msg)
+		dealer.Unregister(sess, msg)
 
 		Convey("The callee should have received an UNREGISTERED message", func() {
 			unreg := callee.received.(*Unregistered).Request
@@ -57,9 +59,9 @@ func TestUnregister(t *testing.T) {
 		})
 
 		Convey("The dealer should no longer have the endpoint registered", func() {
-			_, ok := dealer.registrations[testProcedure]
+			_, ok := dealer.procedures[testProcedure]
 			So(ok, ShouldBeFalse)
-			_, ok = dealer.procedures[reg]
+			_, ok = dealer.registrations[reg]
 			So(ok, ShouldBeFalse)
 		})
 	})
@@ -68,15 +70,17 @@ func TestUnregister(t *testing.T) {
 func TestCall(t *testing.T) {
 	Convey("With a procedure registered", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
-		caller := &TestSender{}
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
+		caller := &TestPeer{}
+		callerSession := &Session{Peer: caller}
 
 		Convey("Calling an invalid procedure", func() {
 			msg := &Call{Request: 124, Procedure: URI("turnpike.test.bad")}
-			dealer.Call(caller, msg)
+			dealer.Call(callerSession, msg)
 
 			Convey("The caller should have received an ERROR message", func() {
 				err := caller.received.(*Error)
@@ -87,7 +91,7 @@ func TestCall(t *testing.T) {
 
 		Convey("Calling a valid procedure", func() {
 			msg := &Call{Request: 125, Procedure: testProcedure}
-			dealer.Call(caller, msg)
+			dealer.Call(callerSession, msg)
 
 			Convey("The callee should have received an INVOCATION message", func() {
 				So(callee.received.MessageType(), ShouldEqual, INVOCATION)
@@ -95,7 +99,7 @@ func TestCall(t *testing.T) {
 
 				Convey("And the callee responds with a YIELD message", func() {
 					msg := &Yield{Request: inv.Request}
-					dealer.Yield(callee, msg)
+					dealer.Yield(sess, msg)
 
 					Convey("The caller should have received a RESULT message", func() {
 						So(caller.received.MessageType(), ShouldEqual, RESULT)
@@ -105,7 +109,7 @@ func TestCall(t *testing.T) {
 
 				Convey("And the callee responds with an ERROR message", func() {
 					msg := &Error{Request: inv.Request}
-					dealer.Error(callee, msg)
+					dealer.Error(sess, msg)
 
 					Convey("The caller should have received an ERROR message", func() {
 						So(caller.received.MessageType(), ShouldEqual, ERROR)
@@ -120,24 +124,23 @@ func TestCall(t *testing.T) {
 func TestRemovePeer(t *testing.T) {
 	Convey("With a procedure registered", t, func() {
 		dealer := NewDefaultDealer().(*defaultDealer)
-		callee := &TestSender{}
+		callee := &TestPeer{}
 		testProcedure := URI("turnpike.test.endpoint")
 		msg := &Register{Request: 123, Procedure: testProcedure}
-		dealer.Register(callee, msg)
+		sess := &Session{Peer: callee}
+		dealer.Register(sess, msg)
 		reg := callee.received.(*Registered).Registration
-		So(dealer.registrations, ShouldContainKey, testProcedure)
-		So(dealer.procedures, ShouldContainKey, reg)
-		So(dealer.callees[callee], ShouldContainKey, reg)
+		So(dealer.procedures, ShouldContainKey, testProcedure)
+		So(dealer.registrations, ShouldContainKey, reg)
 
 		Convey("Calling RemoveSession should remove the registration", func() {
-			dealer.RemovePeer(callee)
+			dealer.RemoveSession(sess)
 			So(dealer.registrations, ShouldNotContainKey, testProcedure)
 			So(dealer.procedures, ShouldNotContainKey, reg)
-			So(dealer.callees[callee], ShouldNotContainKey, reg)
 
 			Convey("And registering the endpoint again should succeed", func() {
 				msg.Request = 124
-				dealer.Register(callee, msg)
+				dealer.Register(sess, msg)
 				So(callee.received.MessageType(), ShouldEqual, REGISTERED)
 			})
 		})

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -2,6 +2,7 @@ package turnpike
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -101,7 +102,11 @@ func TestCall(t *testing.T) {
 					msg := &Yield{Request: inv.Request}
 					dealer.Yield(sess, msg)
 
+					// give it some time to propagate
+					time.Sleep(time.Millisecond)
+
 					Convey("The caller should have received a RESULT message", func() {
+						So(caller.received, ShouldNotBeNil)
 						So(caller.received.MessageType(), ShouldEqual, RESULT)
 						So(caller.received.(*Result).Request, ShouldEqual, 125)
 					})
@@ -111,7 +116,11 @@ func TestCall(t *testing.T) {
 					msg := &Error{Request: inv.Request}
 					dealer.Error(sess, msg)
 
+					// give it some time to propagate
+					time.Sleep(time.Millisecond)
+
 					Convey("The caller should have received an ERROR message", func() {
+						So(caller.received, ShouldNotBeNil)
 						So(caller.received.MessageType(), ShouldEqual, ERROR)
 						So(caller.received.(*Error).Request, ShouldEqual, 125)
 					})

--- a/dealer_test.go
+++ b/dealer_test.go
@@ -84,7 +84,7 @@ func TestCall(t *testing.T) {
 			dealer.Call(callerSession, msg)
 
 			Convey("The caller should have received an ERROR message", func() {
-				err := caller.received.(*Error)
+				err := caller.getReceived().(*Error)
 				So(err.Error, ShouldEqual, ErrNoSuchProcedure)
 				So(err.Details, ShouldNotBeNil)
 			})
@@ -106,9 +106,9 @@ func TestCall(t *testing.T) {
 					time.Sleep(time.Millisecond)
 
 					Convey("The caller should have received a RESULT message", func() {
-						So(caller.received, ShouldNotBeNil)
-						So(caller.received.MessageType(), ShouldEqual, RESULT)
-						So(caller.received.(*Result).Request, ShouldEqual, 125)
+						So(caller.getReceived(), ShouldNotBeNil)
+						So(caller.getReceived().MessageType(), ShouldEqual, RESULT)
+						So(caller.getReceived().(*Result).Request, ShouldEqual, 125)
 					})
 				})
 
@@ -120,9 +120,9 @@ func TestCall(t *testing.T) {
 					time.Sleep(time.Millisecond)
 
 					Convey("The caller should have received an ERROR message", func() {
-						So(caller.received, ShouldNotBeNil)
-						So(caller.received.MessageType(), ShouldEqual, ERROR)
-						So(caller.received.(*Error).Request, ShouldEqual, 125)
+						So(caller.getReceived(), ShouldNotBeNil)
+						So(caller.getReceived().MessageType(), ShouldEqual, ERROR)
+						So(caller.getReceived().(*Error).Request, ShouldEqual, 125)
 					})
 				})
 			})

--- a/examples/auth/client/client.go
+++ b/examples/auth/client/client.go
@@ -29,9 +29,14 @@ func main() {
 	turnpike.Debug()
 	fmt.Println("Hint: the password is 'password'")
 	fmt.Print("Password: ")
-	password = gopass.GetPasswd()
 
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/ws")
+	var err error
+	password, err = gopass.GetPasswd()
+	if err != nil {
+		log.Fatal("Error getting the password:", err)
+	}
+
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/ws", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/auth/client/client.go
+++ b/examples/auth/client/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/howeyc/gopass"
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 var password []byte

--- a/examples/auth/server/server.go
+++ b/examples/auth/server/server.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 
 	"github.com/satori/go.uuid"
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 // this is just an example, please don't actually use it

--- a/examples/autobahn/server/main.go
+++ b/examples/autobahn/server/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/examples/chat/chatclient/main.go
+++ b/examples/chat/chatclient/main.go
@@ -36,7 +36,7 @@ func main() {
 	username := os.Args[1]
 
 	// turnpike.Debug()
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/")
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/chat/chatclient/main.go
+++ b/examples/chat/chatclient/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 const (

--- a/examples/chat/chatserver/main.go
+++ b/examples/chat/chatserver/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/examples/meta-api/meta-client.go
+++ b/examples/meta-api/meta-client.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/")
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/meta-api/meta-client.go
+++ b/examples/meta-api/meta-client.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/examples/rpc/rpc-client/main.go
+++ b/examples/rpc/rpc-client/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/examples/rpc/rpc-client/main.go
+++ b/examples/rpc/rpc-client/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	turnpike.Debug()
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/")
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/rpc/rpc-server/main.go
+++ b/examples/rpc/rpc-server/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 var client *turnpike.Client

--- a/examples/web/server.go
+++ b/examples/web/server.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 func main() {

--- a/interceptor.go
+++ b/interceptor.go
@@ -6,7 +6,7 @@ package turnpike
 // Intercept takes the session and (a pointer to) the message, and (possibly)
 // modifies the message.
 type Interceptor interface {
-	Intercept(session Session, msg *Message)
+	Intercept(session *Session, msg *Message)
 }
 
 // DefaultInterceptor does nothing :)
@@ -18,5 +18,5 @@ func NewDefaultInterceptor() Interceptor {
 	return &defaultInterceptor{}
 }
 
-func (di *defaultInterceptor) Intercept(session Session, msg *Message) {
+func (di *defaultInterceptor) Intercept(session *Session, msg *Message) {
 }

--- a/realm.go
+++ b/realm.go
@@ -44,7 +44,10 @@ func (r *Realm) getPeer(details map[string]interface{}) (Peer, error) {
 	if details == nil {
 		details = make(map[string]interface{})
 	}
-	go r.handleSession(sess)
+	go func() {
+		r.handleSession(sess)
+		sess.Close()
+	}()
 	log.Println("Established internal session:", sess)
 	return peerB, nil
 }

--- a/realm.go
+++ b/realm.go
@@ -194,6 +194,7 @@ func (r *Realm) handleSession(sess *Session) {
 		defer r.lock.RUnlock()
 
 		r.clients.Remove(string(sess.Id))
+		r.Broker.RemoveSession(sess)
 		r.Dealer.RemoveSession(sess)
 		r.localClient.onLeave(sess.Id)
 	}()

--- a/realm.go
+++ b/realm.go
@@ -24,7 +24,7 @@ type Realm struct {
 	Authenticators   map[string]Authenticator
 	// DefaultAuth      func(details map[string]interface{}) (map[string]interface{}, error)
 	AuthTimeout time.Duration
-	clients     map[ID]Session
+	clients     map[ID]*Session
 	localClient
 }
 
@@ -34,7 +34,7 @@ type localClient struct {
 
 func (r *Realm) getPeer(details map[string]interface{}) (Peer, error) {
 	peerA, peerB := localPipe()
-	sess := Session{Peer: peerA, Id: NewID(), Details: details, kill: make(chan URI, 1)}
+	sess := &Session{Peer: peerA, Id: NewID(), Details: details, kill: make(chan URI, 1)}
 	if details == nil {
 		details = make(map[string]interface{})
 	}
@@ -51,7 +51,7 @@ func (r Realm) Close() {
 }
 
 func (r *Realm) init() {
-	r.clients = make(map[ID]Session)
+	r.clients = make(map[ID]*Session)
 	p, _ := r.getPeer(nil)
 	r.localClient.Client = NewClient(p)
 	if r.Broker == nil {
@@ -82,12 +82,12 @@ func (l *localClient) onLeave(session ID) {
 	l.Publish("wamp.session.on_leave", []interface{}{session}, nil)
 }
 
-func (r *Realm) handleSession(sess Session) {
+func (r *Realm) handleSession(sess *Session) {
 	r.clients[sess.Id] = sess
 	r.onJoin(sess.Details)
 	defer func() {
 		delete(r.clients, sess.Id)
-		r.Dealer.RemovePeer(sess.Peer)
+		r.Dealer.RemoveSession(sess)
 		r.onLeave(sess.Id)
 	}()
 	c := sess.Receive()
@@ -133,27 +133,27 @@ func (r *Realm) handleSession(sess Session) {
 
 		// Broker messages
 		case *Publish:
-			r.Broker.Publish(sess.Peer, msg)
+			r.Broker.Publish(sess, msg)
 		case *Subscribe:
-			r.Broker.Subscribe(sess.Peer, msg)
+			r.Broker.Subscribe(sess, msg)
 		case *Unsubscribe:
-			r.Broker.Unsubscribe(sess.Peer, msg)
+			r.Broker.Unsubscribe(sess, msg)
 
 		// Dealer messages
 		case *Register:
-			r.Dealer.Register(sess.Peer, msg)
+			r.Dealer.Register(sess, msg)
 		case *Unregister:
-			r.Dealer.Unregister(sess.Peer, msg)
+			r.Dealer.Unregister(sess, msg)
 		case *Call:
-			r.Dealer.Call(sess.Peer, msg)
+			r.Dealer.Call(sess, msg)
 		case *Yield:
-			r.Dealer.Yield(sess.Peer, msg)
+			r.Dealer.Yield(sess, msg)
 
 		// Error messages
 		case *Error:
 			if msg.Type == INVOCATION {
 				// the only type of ERROR message the router should receive
-				r.Dealer.Error(sess.Peer, msg)
+				r.Dealer.Error(sess, msg)
 			} else {
 				log.Printf("invalid ERROR message received: %v", msg)
 			}

--- a/router.go
+++ b/router.go
@@ -149,7 +149,7 @@ func (r *defaultRouter) Accept(client Peer) error {
 	// session details
 	welcome.Details["session"] = welcome.Id
 	welcome.Details["realm"] = hello.Realm
-	sess := Session{
+	sess := &Session{
 		Peer:    client,
 		Id:      welcome.Id,
 		Details: welcome.Details,

--- a/session.go
+++ b/session.go
@@ -35,8 +35,8 @@ func (s *Session) NextRequestId() ID {
 // appear in the Receive of the other. This is useful for implementing
 // client sessions
 func localPipe() (*localPeer, *localPeer) {
-	aToB := make(chan Message, 10)
-	bToA := make(chan Message, 10)
+	aToB := make(chan Message, 100)
+	bToA := make(chan Message, 100)
 
 	a := &localPeer{
 		incoming: bToA,

--- a/session.go
+++ b/session.go
@@ -4,17 +4,31 @@ import (
 	"fmt"
 )
 
+const (
+	MAX_REQUEST_ID = 1 << 53
+)
+
 // Session represents an active WAMP session
 type Session struct {
 	Peer
 	Id      ID
 	Details map[string]interface{}
 
-	kill chan URI
+	lastRequestId ID
+	kill          chan URI
 }
 
 func (s Session) String() string {
 	return fmt.Sprintf("%d", s.Id)
+}
+
+func (s *Session) NextRequestId() ID {
+	s.lastRequestId++
+	// max value is 2^53
+	if s.lastRequestId > MAX_REQUEST_ID {
+		s.lastRequestId = 1
+	}
+	return s.lastRequestId
 }
 
 // localPipe creates two linked sessions. Messages sent to one will

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,21 @@
+package turnpike
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNextRequestId(t *testing.T) {
+	Convey("Incrementing session id", t, func() {
+		sess := &Session{}
+		Convey("Should increment on subsequent calls", func() {
+			So(sess.NextRequestId(), ShouldEqual, 1)
+			So(sess.NextRequestId(), ShouldEqual, 2)
+		})
+		Convey("Should roll over upon reaching the max session id size", func() {
+			sess.lastRequestId = MAX_REQUEST_ID
+			So(sess.NextRequestId(), ShouldEqual, 1)
+		})
+	})
+}

--- a/turnpike/main.go
+++ b/turnpike/main.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"time"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"gopkg.in/beatgammit/turnpike.v2"
 )
 
 var (

--- a/websocket.go
+++ b/websocket.go
@@ -164,7 +164,8 @@ func (ep *websocketPeer) run() {
 				log.Println("peer connection closed")
 			} else {
 				log.Println("error reading from peer:", err)
-				if !websocket.IsCloseError(err) {
+				// only expected errors seem to close the connection, so close on any unexpected errors
+				if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 					ep.conn.Close()
 				}
 			}

--- a/websocket.go
+++ b/websocket.go
@@ -86,8 +86,11 @@ func (ep *websocketPeer) run() {
 				log.Println("peer connection closed")
 			} else {
 				log.Println("error reading from peer:", err)
-				ep.conn.Close()
+				if !websocket.IsCloseError(err) {
+					ep.conn.Close()
+				}
 			}
+			log.Println("Closing channel")
 			close(ep.messages)
 			break
 		} else if msgType == websocket.CloseMessage {

--- a/websocket.go
+++ b/websocket.go
@@ -2,6 +2,7 @@ package turnpike
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -13,6 +14,7 @@ type websocketPeer struct {
 	messages    chan Message
 	payloadType int
 	closed      bool
+	mutex       sync.Mutex
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
@@ -56,6 +58,8 @@ func (ep *websocketPeer) Send(msg Message) error {
 	if err != nil {
 		return err
 	}
+	ep.mutex.Lock()
+	defer ep.mutex.Unlock()
 	return ep.conn.WriteMessage(ep.payloadType, b)
 }
 func (ep *websocketPeer) Receive() <-chan Message {

--- a/websocket.go
+++ b/websocket.go
@@ -2,6 +2,7 @@ package turnpike
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -9,13 +10,22 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// errors.
+var (
+	ErrWSSendTimeout = errors.New("ws peer send timeout")
+	ErrWSIsClosed    = errors.New("ws peer is closed")
+)
+
 type websocketPeer struct {
 	conn        *websocket.Conn
 	serializer  Serializer
+	sendMsgs    chan Message
 	messages    chan Message
 	payloadType int
-	closed      bool
 	mutex       sync.Mutex
+	inSending   chan struct{}
+	closing     chan struct{}
+	*ConnectionConfig
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
@@ -44,45 +54,113 @@ func newWebsocketPeer(url, protocol, origin string, serializer Serializer, paylo
 		return nil, err
 	}
 	ep := &websocketPeer{
-		conn:        conn,
-		messages:    make(chan Message, 100),
-		serializer:  serializer,
-		payloadType: payloadType,
+		conn:             conn,
+		sendMsgs:         make(chan Message, 16),
+		messages:         make(chan Message, 100),
+		serializer:       serializer,
+		payloadType:      payloadType,
+		closing:          make(chan struct{}),
+		ConnectionConfig: &ConnectionConfig{},
 	}
 	go ep.run()
 
 	return ep, nil
 }
 
-// TODO: make this just add the message to a channel so we don't block
 func (ep *websocketPeer) Send(msg Message) error {
-	b, err := ep.serializer.Serialize(msg)
-	if err != nil {
-		return err
+	select {
+	case ep.sendMsgs <- msg:
+		return nil
+	case <-time.After(5 * time.Second):
+		log.Println(ErrWSSendTimeout.Error())
+		ep.Close()
+		return ErrWSSendTimeout
+	case <-ep.closing:
+		log.Println(ErrWSIsClosed.Error())
+		return ErrWSIsClosed
 	}
-	ep.mutex.Lock()
-	defer ep.mutex.Unlock()
-	return ep.conn.WriteMessage(ep.payloadType, b)
 }
+
 func (ep *websocketPeer) Receive() <-chan Message {
 	return ep.messages
 }
+
+func (ep *websocketPeer) doClosing() {
+	ep.mutex.Lock()
+	defer ep.mutex.Unlock()
+
+	select {
+	case <-ep.closing:
+	default:
+		close(ep.closing)
+	}
+}
+
+func (ep *websocketPeer) isClosed() bool {
+	select {
+	case <-ep.closing:
+		return true
+	default:
+		return false
+	}
+}
+
 func (ep *websocketPeer) Close() error {
+	if ep.isClosed() {
+		return nil
+	}
+	ep.doClosing()
+
+	if ep.inSending != nil {
+		<-ep.inSending
+	}
+
 	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "goodbye")
 	err := ep.conn.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(5*time.Second))
 	if err != nil {
 		log.Println("error sending close message:", err)
 	}
-	ep.closed = true
+
 	return ep.conn.Close()
 }
 
+func (ep *websocketPeer) updateReadDeadline() {
+	ep.mutex.Lock()
+	defer ep.mutex.Unlock()
+	if ep.IdleTimeout > 0 {
+		ep.conn.SetReadDeadline(time.Now().Add(ep.IdleTimeout))
+	}
+}
+
+func (ep *websocketPeer) setReadDead() {
+	ep.mutex.Lock()
+	defer ep.mutex.Unlock()
+	ep.conn.SetReadDeadline(time.Now())
+}
+
 func (ep *websocketPeer) run() {
+	go ep.sending()
+
+	if ep.MaxMsgSize > 0 {
+		ep.conn.SetReadLimit(ep.MaxMsgSize)
+	}
+	ep.conn.SetPongHandler(func(v string) error {
+		log.Println("pong:", v)
+		ep.updateReadDeadline()
+		return nil
+	})
+	ep.conn.SetPingHandler(func(v string) error {
+		log.Println("ping:", v)
+		ep.updateReadDeadline()
+		return nil
+	})
+
 	for {
 		// TODO: use conn.NextMessage() and stream
 		// TODO: do something different based on binary/text frames
+		ep.updateReadDeadline()
 		if msgType, b, err := ep.conn.ReadMessage(); err != nil {
-			if ep.closed {
+			if ep.isClosed() {
 				log.Println("peer connection closed")
 			} else {
 				log.Println("error reading from peer:", err)
@@ -107,4 +185,68 @@ func (ep *websocketPeer) run() {
 			}
 		}
 	}
+}
+
+func (ep *websocketPeer) sending() {
+	ep.inSending = make(chan struct{})
+	var ticker *time.Ticker
+	if ep.PingTimeout == 0 {
+		ticker = time.NewTicker(7 * 24 * time.Hour)
+	} else {
+		ticker = time.NewTicker(ep.PingTimeout)
+	}
+
+	defer func() {
+		ep.setReadDead()
+		ticker.Stop()
+		close(ep.inSending)
+	}()
+
+	for {
+		select {
+		case msg := <-ep.sendMsgs:
+			if closed, _ := ep.doSend(msg); closed {
+				return
+			}
+		case <-ticker.C:
+			wt := ep.WriteTimeout
+			if wt == 0 {
+				wt = 10 * time.Second
+			}
+			if err := ep.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(wt)); err != nil {
+				log.Println("error sending ping message:", err)
+				return
+			}
+		case <-ep.closing:
+			// sending remaining messages.
+			for {
+				select {
+				case msg := <-ep.sendMsgs:
+					if closed, _ := ep.doSend(msg); !closed {
+						continue
+					}
+				default:
+				}
+				break
+			}
+			return
+		}
+		ep.updateReadDeadline()
+	}
+}
+
+func (ep *websocketPeer) doSend(msg Message) (closed bool, err error) {
+	b, err := ep.serializer.Serialize(msg)
+	if err != nil {
+		log.Printf("error serializing peer message: %s, %+v", err, msg)
+		return true, err
+	}
+	if ep.WriteTimeout > 0 {
+		ep.conn.SetWriteDeadline(time.Now().Add(ep.WriteTimeout))
+	}
+	if err = ep.conn.WriteMessage(ep.payloadType, b); err != nil {
+		log.Println("error write message: ", err)
+		return true, err
+	}
+	return
 }

--- a/websocket.go
+++ b/websocket.go
@@ -43,7 +43,7 @@ func newWebsocketPeer(url, protocol, origin string, serializer Serializer, paylo
 	}
 	ep := &websocketPeer{
 		conn:        conn,
-		messages:    make(chan Message, 10),
+		messages:    make(chan Message, 100),
 		serializer:  serializer,
 		payloadType: payloadType,
 	}

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -137,7 +137,7 @@ func (s *WebsocketServer) handleWebsocket(conn *websocket.Conn) {
 	peer := websocketPeer{
 		conn:        conn,
 		serializer:  serializer,
-		messages:    make(chan Message, 10),
+		messages:    make(chan Message, 100),
 		payloadType: payloadType,
 	}
 	go peer.run()


### PR DESCRIPTION
- allows us to generate session-specific ids

I basically rewrote `dealer.go` on a rereading of the spec. I was getting errors with AutobahnPython saying that the INVOCATION ID was reused (was causing somewhat random crashes). We were using `NewID()` to generate this, which generates the ID randomly, so I switched it to a session-specific, incrementing ID as per the spec. I also simplified some of the internal data structures.

Moving the *Session into the Dealer is a breaking change and was needed to generate session-specific identifiers for the fix. We talked about this previously, and we had decided not to do it because there wasn't a reason to complicate matters, but I think this is now necessary to be spec compliant.

If this looks good to you, I can check if our ids are correct elsewhere.
