### PR TITLE
add tls config parameter to websocket client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package turnpike
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 )
@@ -51,8 +52,8 @@ type eventDesc struct {
 
 // NewWebsocketClient creates a new websocket client connected to the specified
 // `url` and using the specified `serialization`.
-func NewWebsocketClient(serialization Serialization, url string) (*Client, error) {
-	p, err := NewWebsocketPeer(serialization, url, "")
+func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Config) (*Client, error) {
+	p, err := NewWebsocketPeer(serialization, url, "", tlscfg)
 	if err != nil {
 		return nil, err
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -1,6 +1,7 @@
 package turnpike
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -16,24 +17,25 @@ type websocketPeer struct {
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
-func NewWebsocketPeer(serialization Serialization, url, origin string) (Peer, error) {
+func NewWebsocketPeer(serialization Serialization, url, origin string, tlscfg *tls.Config) (Peer, error) {
 	switch serialization {
 	case JSON:
 		return newWebsocketPeer(url, jsonWebsocketProtocol, origin,
-			new(JSONSerializer), websocket.TextMessage,
+			new(JSONSerializer), websocket.TextMessage, tlscfg,
 		)
 	case MSGPACK:
 		return newWebsocketPeer(url, msgpackWebsocketProtocol, origin,
-			new(MessagePackSerializer), websocket.BinaryMessage,
+			new(MessagePackSerializer), websocket.BinaryMessage, tlscfg,
 		)
 	default:
 		return nil, fmt.Errorf("Unsupported serialization: %v", serialization)
 	}
 }
 
-func newWebsocketPeer(url, protocol, origin string, serializer Serializer, payloadType int) (Peer, error) {
+func newWebsocketPeer(url, protocol, origin string, serializer Serializer, payloadType int, tlscfg *tls.Config) (Peer, error) {
 	dialer := websocket.Dialer{
-		Subprotocols: []string{protocol},
+		Subprotocols:    []string{protocol},
+		TLSClientConfig: tlscfg,
 	}
 	conn, _, err := dialer.Dial(url, nil)
 	if err != nil {

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -29,7 +29,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost")
+	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost")
+	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I'm not sure if this aligns with the spec or not, but we have a desire to use client certs to protect all of our services. Please let me know if there's a more WAMP-spec oriented way to accomplish this.
