### PR TITLE
Fix realm concurrent writes and added exclude_me option to broker

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1,7 +1,5 @@
 package turnpike
 
-import _ "log"
-
 // Broker is the interface implemented by an object that handles routing EVENTS
 // from Publishers to Subscribers.
 type Broker interface {

--- a/broker.go
+++ b/broker.go
@@ -1,5 +1,7 @@
 package turnpike
 
+import _ "log"
+
 // Broker is the interface implemented by an object that handles routing EVENTS
 // from Publishers to Subscribers.
 type Broker interface {
@@ -38,12 +40,18 @@ func (br *defaultBroker) Publish(pub Sender, msg *Publish) {
 		ArgumentsKw: msg.ArgumentsKw,
 		Details:     make(map[string]interface{}),
 	}
+
+	excludePublisher := true
+	if exclude, ok := msg.Options["exclude_me"].(bool); ok {
+		excludePublisher = exclude
+	}
+
 	for id, sub := range br.routes[msg.Topic] {
 		// shallow-copy the template
 		event := evtTemplate
 		event.Subscription = id
 		// don't send event to publisher
-		if sub != pub {
+		if (excludePublisher && sub != pub) || !excludePublisher {
 			sub.Send(&event)
 		}
 	}


### PR DESCRIPTION
Added mutex to realm to prevent concurrent map writes, take a look at #112 first.

Added exclude_me option to broker: https://tools.ietf.org/html/draft-oberstet-hybi-tavendo-wamp-02#section-13.5
