### PR TITLE
Serialize write access to websocket

### DIFF
--- a/examples/auth/client/client.go
+++ b/examples/auth/client/client.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/awakenetworks/turnpike"
 	"github.com/howeyc/gopass"
-	"gopkg.in/jcelliott/turnpike.v2"
 )
 
 var password []byte
@@ -29,7 +29,11 @@ func main() {
 	turnpike.Debug()
 	fmt.Println("Hint: the password is 'password'")
 	fmt.Print("Password: ")
-	password = gopass.GetPasswd()
+	var err error
+	password, err = gopass.GetPasswd()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/ws")
 	if err != nil {

--- a/examples/auth/server/server.go
+++ b/examples/auth/server/server.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/awakenetworks/turnpike"
 	"github.com/satori/go.uuid"
-	"gopkg.in/jcelliott/turnpike.v2"
 )
 
 // this is just an example, please don't actually use it

--- a/examples/autobahn/server/main.go
+++ b/examples/autobahn/server/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 func main() {

--- a/examples/chat/chatclient/main.go
+++ b/examples/chat/chatclient/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 const (

--- a/examples/chat/chatserver/main.go
+++ b/examples/chat/chatserver/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 func main() {

--- a/examples/meta-api/meta-client.go
+++ b/examples/meta-api/meta-client.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 func main() {

--- a/examples/rpc/rpc-client/main.go
+++ b/examples/rpc/rpc-client/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 func main() {

--- a/examples/rpc/rpc-server/main.go
+++ b/examples/rpc/rpc-server/main.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 var client *turnpike.Client

--- a/examples/web/server.go
+++ b/examples/web/server.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/http"
 
-	"gopkg.in/jcelliott/turnpike.v2"
+	"github.com/awakenetworks/turnpike"
 )
 
 func main() {

--- a/websocket.go
+++ b/websocket.go
@@ -2,6 +2,7 @@ package turnpike
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -13,6 +14,7 @@ type websocketPeer struct {
 	messages    chan Message
 	payloadType int
 	closed      bool
+	writeMutex  sync.Mutex
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
@@ -56,6 +58,8 @@ func (ep *websocketPeer) Send(msg Message) error {
 	if err != nil {
 		return err
 	}
+	ep.writeMutex.Lock()
+	defer ep.writeMutex.Unlock()
 	return ep.conn.WriteMessage(ep.payloadType, b)
 }
 func (ep *websocketPeer) Receive() <-chan Message {


### PR DESCRIPTION
As the gorilla websocket documentation makes clear, it is the callers
responsibility to ensure there is only 1 concurrent reader and writer to
every websocket.

While investigating alternative Broker implementations which are
asynchronous, I was able to trigger go data race warnings while writing
to the socket from subscriptions which were writing from different
goroutines to the same client.

Add a simple mutex on the websocketPeer to gate writers on Send.
Looking at the current implementation there should only be one reader
from the websocket a time which writes to a messages channel.

This should help with issue #105 and is low hanging fruit. It is the most obvious fix until the code is refactored to use a Send message channel where all the writes would be serialized by the channel.
