### PR TITLE
Fixes for all detectable turnpike concurrency issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,6 +157,7 @@ func (c *Client) joinRealmCRA(realm string, details map[string]interface{}) (map
 	}
 	if msg, err := GetMessageTimeout(c.Peer, c.ReceiveTimeout); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	} else if welcome, ok := msg.(*Welcome); !ok {
 		c.Send(abortUnexpectedMsg)

--- a/client.go
+++ b/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	listeners    map[ID]chan Message
 	events       map[ID]*eventDesc
 	procedures   map[ID]*procedureDesc
+	acts         chan func()
 	requestCount uint
 }
 
@@ -68,9 +69,21 @@ func NewClient(p Peer) *Client {
 		listeners:      make(map[ID]chan Message),
 		events:         make(map[ID]*eventDesc),
 		procedures:     make(map[ID]*procedureDesc),
+		acts:           make(chan func()),
 		requestCount:   0,
 	}
+	go c.run()
 	return c
+}
+
+func (c *Client) run() {
+	for {
+		if act, ok := <-c.acts; ok {
+			act()
+		} else {
+			return
+		}
+	}
 }
 
 // JoinRealm joins a WAMP realm, but does not handle challenge/response authentication.
@@ -84,14 +97,17 @@ func (c *Client) JoinRealm(realm string, details map[string]interface{}) (map[st
 	}
 	if err := c.Send(&Hello{Realm: URI(realm), Details: details}); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	}
 	if msg, err := GetMessageTimeout(c.Peer, c.ReceiveTimeout); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	} else if welcome, ok := msg.(*Welcome); !ok {
 		c.Send(abortUnexpectedMsg)
 		c.Peer.Close()
+		close(c.acts)
 		return nil, fmt.Errorf(formatUnexpectedMessage(msg, WELCOME))
 	} else {
 		go c.Receive()
@@ -112,25 +128,31 @@ func (c *Client) joinRealmCRA(realm string, details map[string]interface{}) (map
 	details["authmethods"] = authmethods
 	if err := c.Send(&Hello{Realm: URI(realm), Details: details}); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	}
 	if msg, err := GetMessageTimeout(c.Peer, c.ReceiveTimeout); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	} else if challenge, ok := msg.(*Challenge); !ok {
 		c.Send(abortUnexpectedMsg)
 		c.Peer.Close()
+		close(c.acts)
 		return nil, fmt.Errorf(formatUnexpectedMessage(msg, CHALLENGE))
 	} else if authFunc, ok := c.Auth[challenge.AuthMethod]; !ok {
 		c.Send(abortNoAuthHandler)
 		c.Peer.Close()
+		close(c.acts)
 		return nil, fmt.Errorf("no auth handler for method: %s", challenge.AuthMethod)
 	} else if signature, authDetails, err := authFunc(details, challenge.Extra); err != nil {
 		c.Send(abortAuthFailure)
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	} else if err := c.Send(&Authenticate{Signature: signature, Extra: authDetails}); err != nil {
 		c.Peer.Close()
+		close(c.acts)
 		return nil, err
 	}
 	if msg, err := GetMessageTimeout(c.Peer, c.ReceiveTimeout); err != nil {
@@ -139,6 +161,7 @@ func (c *Client) joinRealmCRA(realm string, details map[string]interface{}) (map
 	} else if welcome, ok := msg.(*Welcome); !ok {
 		c.Send(abortUnexpectedMsg)
 		c.Peer.Close()
+		close(c.acts)
 		return nil, fmt.Errorf(formatUnexpectedMessage(msg, WELCOME))
 	} else {
 		go c.Receive()
@@ -212,11 +235,7 @@ func (c *Client) Receive() {
 		switch msg := msg.(type) {
 
 		case *Event:
-			if event, ok := c.events[msg.Subscription]; ok {
-				go event.handler(msg.Arguments, msg.ArgumentsKw)
-			} else {
-				log.Println("no handler registered for subscription:", msg.Subscription)
-			}
+			c.handleEvent(msg)
 
 		case *Invocation:
 			c.handleInvocation(msg)
@@ -242,6 +261,8 @@ func (c *Client) Receive() {
 			log.Println("unhandled message:", msg.MessageType(), msg)
 		}
 	}
+
+	close(c.acts)
 	log.Println("client closed")
 
 	if c.ReceiveDone != nil {
@@ -249,9 +270,32 @@ func (c *Client) Receive() {
 	}
 }
 
+func (c *Client) handleEvent(msg *Event) {
+	sync := make(chan struct{})
+	c.acts <- func() {
+		if event, ok := c.events[msg.Subscription]; ok {
+			go event.handler(msg.Arguments, msg.ArgumentsKw)
+		} else {
+			log.Println("no handler registered for subscription:", msg.Subscription)
+		}
+		sync <- struct{}{}
+	}
+	<-sync
+}
+
 func (c *Client) notifyListener(msg Message, requestID ID) {
 	// pass in the request ID so we don't have to do any type assertion
-	if l, ok := c.listeners[requestID]; ok {
+	var (
+		sync = make(chan struct{})
+		l    chan Message
+		ok   bool
+	)
+	c.acts <- func() {
+		l, ok = c.listeners[requestID]
+		sync <- struct{}{}
+	}
+	<-sync
+	if ok {
 		l <- msg
 	} else {
 		log.Println("no listener for message", msg.MessageType(), requestID)
@@ -259,65 +303,88 @@ func (c *Client) notifyListener(msg Message, requestID ID) {
 }
 
 func (c *Client) handleInvocation(msg *Invocation) {
-	if proc, ok := c.procedures[msg.Registration]; ok {
-		go func() {
-			result := proc.handler(msg.Arguments, msg.ArgumentsKw, msg.Details)
+	sync := make(chan struct{})
+	c.acts <- func() {
+		if proc, ok := c.procedures[msg.Registration]; ok {
+			go func() {
+				result := proc.handler(msg.Arguments, msg.ArgumentsKw, msg.Details)
 
-			var tosend Message
-			tosend = &Yield{
-				Request:     msg.Request,
-				Options:     make(map[string]interface{}),
-				Arguments:   result.Args,
-				ArgumentsKw: result.Kwargs,
-			}
-
-			if result.Err != "" {
-				tosend = &Error{
-					Type:        INVOCATION,
+				var tosend Message
+				tosend = &Yield{
 					Request:     msg.Request,
-					Details:     make(map[string]interface{}),
+					Options:     make(map[string]interface{}),
 					Arguments:   result.Args,
 					ArgumentsKw: result.Kwargs,
-					Error:       result.Err,
 				}
-			}
 
-			if err := c.Send(tosend); err != nil {
+				if result.Err != "" {
+					tosend = &Error{
+						Type:        INVOCATION,
+						Request:     msg.Request,
+						Details:     make(map[string]interface{}),
+						Arguments:   result.Args,
+						ArgumentsKw: result.Kwargs,
+						Error:       result.Err,
+					}
+				}
+
+				c.acts <- func() {
+					if err := c.Send(tosend); err != nil {
+						log.Println("error sending message:", err)
+					}
+				}
+			}()
+		} else {
+			log.Println("no handler registered for registration:", msg.Registration)
+			if err := c.Send(&Error{
+				Type:    INVOCATION,
+				Request: msg.Request,
+				Details: make(map[string]interface{}),
+				Error:   URI(fmt.Sprintf("no handler for registration: %v", msg.Registration)),
+			}); err != nil {
 				log.Println("error sending message:", err)
 			}
-		}()
-	} else {
-		log.Println("no handler registered for registration:", msg.Registration)
-		if err := c.Send(&Error{
-			Type:    INVOCATION,
-			Request: msg.Request,
-			Details: make(map[string]interface{}),
-			Error:   URI(fmt.Sprintf("no handler for registration: %v", msg.Registration)),
-		}); err != nil {
-			log.Println("error sending message:", err)
 		}
+		sync <- struct{}{}
 	}
+	<-sync
 }
 
 func (c *Client) registerListener(id ID) {
 	log.Println("register listener:", id)
 	wait := make(chan Message, 1)
-	c.listeners[id] = wait
+	sync := make(chan struct{})
+	c.acts <- func() {
+		c.listeners[id] = wait
+		sync <- struct{}{}
+	}
+	<-sync
 }
 
 func (c *Client) waitOnListener(id ID) (msg Message, err error) {
 	log.Println("wait on listener:", id)
-	wait, ok := c.listeners[id]
+	var (
+		sync = make(chan struct{})
+		wait chan Message
+		ok   bool
+	)
+	c.acts <- func() {
+		wait, ok = c.listeners[id]
+		sync <- struct{}{}
+	}
+	<-sync
 	if !ok {
 		return nil, fmt.Errorf("unknown listener ID: %v", id)
 	}
 	select {
 	case msg = <-wait:
-		return
 	case <-time.After(c.ReceiveTimeout):
 		err = fmt.Errorf("timeout while waiting for message")
-		return
 	}
+	c.acts <- func() {
+		delete(c.listeners, id)
+	}
+	return
 }
 
 // EventHandler handles a publish event.
@@ -325,6 +392,10 @@ type EventHandler func(args []interface{}, kwargs map[string]interface{})
 
 // Subscribe registers the EventHandler to be called for every message in the provided topic.
 func (c *Client) Subscribe(topic string, fn EventHandler) error {
+	var (
+		sync = make(chan struct{})
+		err  error
+	)
 	id := NewID()
 	c.registerListener(id)
 	sub := &Subscribe{
@@ -332,7 +403,12 @@ func (c *Client) Subscribe(topic string, fn EventHandler) error {
 		Options: make(map[string]interface{}),
 		Topic:   URI(topic),
 	}
-	if err := c.Send(sub); err != nil {
+	c.acts <- func() {
+		err = c.Send(sub)
+		sync <- struct{}{}
+	}
+	<-sync
+	if err != nil {
 		return err
 	}
 	// wait to receive SUBSCRIBED message
@@ -345,7 +421,11 @@ func (c *Client) Subscribe(topic string, fn EventHandler) error {
 		return fmt.Errorf(formatUnexpectedMessage(msg, SUBSCRIBED))
 	} else {
 		// register the event handler with this subscription
-		c.events[subscribed.Subscription] = &eventDesc{topic, fn}
+		c.acts <- func() {
+			c.events[subscribed.Subscription] = &eventDesc{topic, fn}
+			sync <- struct{}{}
+		}
+		<-sync
 	}
 	return nil
 }
@@ -353,15 +433,22 @@ func (c *Client) Subscribe(topic string, fn EventHandler) error {
 // Unsubscribe removes the registered EventHandler from the topic.
 func (c *Client) Unsubscribe(topic string) error {
 	var (
+		sync           = make(chan struct{})
 		subscriptionID ID
 		found          bool
+		err            error
 	)
-	for id, desc := range c.events {
-		if desc.topic == topic {
-			subscriptionID = id
-			found = true
+	c.acts <- func() {
+		for id, desc := range c.events {
+			if desc.topic == topic {
+				subscriptionID = id
+				found = true
+				break
+			}
 		}
+		sync <- struct{}{}
 	}
+	<-sync
 	if !found {
 		return fmt.Errorf("Event %s is not registered with this client.", topic)
 	}
@@ -372,7 +459,12 @@ func (c *Client) Unsubscribe(topic string) error {
 		Request:      id,
 		Subscription: subscriptionID,
 	}
-	if err := c.Send(sub); err != nil {
+	c.acts <- func() {
+		err = c.Send(sub)
+		sync <- struct{}{}
+	}
+	<-sync
+	if err != nil {
 		return err
 	}
 	// wait to receive UNSUBSCRIBED message
@@ -384,7 +476,11 @@ func (c *Client) Unsubscribe(topic string) error {
 	} else if _, ok := msg.(*Unsubscribed); !ok {
 		return fmt.Errorf(formatUnexpectedMessage(msg, UNSUBSCRIBED))
 	}
-	delete(c.events, subscriptionID)
+	c.acts <- func() {
+		delete(c.events, subscriptionID)
+		sync <- struct{}{}
+	}
+	<-sync
 	return nil
 }
 
@@ -395,6 +491,10 @@ type MethodHandler func(
 
 // Register registers a MethodHandler procedure with the router.
 func (c *Client) Register(procedure string, fn MethodHandler, options map[string]interface{}) error {
+	var (
+		sync = make(chan struct{})
+		err  error
+	)
 	id := NewID()
 	c.registerListener(id)
 	register := &Register{
@@ -402,7 +502,12 @@ func (c *Client) Register(procedure string, fn MethodHandler, options map[string
 		Options:   options,
 		Procedure: URI(procedure),
 	}
-	if err := c.Send(register); err != nil {
+	c.acts <- func() {
+		err = c.Send(register)
+		sync <- struct{}{}
+	}
+	<-sync
+	if err != nil {
 		return err
 	}
 
@@ -416,7 +521,11 @@ func (c *Client) Register(procedure string, fn MethodHandler, options map[string
 		return fmt.Errorf(formatUnexpectedMessage(msg, REGISTERED))
 	} else {
 		// register the event handler with this registration
-		c.procedures[registered.Registration] = &procedureDesc{procedure, fn}
+		c.acts <- func() {
+			c.procedures[registered.Registration] = &procedureDesc{procedure, fn}
+			sync <- struct{}{}
+		}
+		<-sync
 	}
 	return nil
 }
@@ -436,15 +545,22 @@ func (c *Client) BasicRegister(procedure string, fn BasicMethodHandler) error {
 // Unregister removes a procedure with the router
 func (c *Client) Unregister(procedure string) error {
 	var (
+		sync        = make(chan struct{})
 		procedureID ID
 		found       bool
+		err         error
 	)
-	for id, p := range c.procedures {
-		if p.name == procedure {
-			procedureID = id
-			found = true
+	c.acts <- func() {
+		for id, p := range c.procedures {
+			if p.name == procedure {
+				procedureID = id
+				found = true
+				break
+			}
 		}
+		sync <- struct{}{}
 	}
+	<-sync
 	if !found {
 		return fmt.Errorf("Procedure %s is not registered with this client.", procedure)
 	}
@@ -454,7 +570,12 @@ func (c *Client) Unregister(procedure string) error {
 		Request:      id,
 		Registration: procedureID,
 	}
-	if err := c.Send(unregister); err != nil {
+	c.acts <- func() {
+		err = c.Send(unregister)
+		sync <- struct{}{}
+	}
+	<-sync
+	if err != nil {
 		return err
 	}
 
@@ -468,19 +589,32 @@ func (c *Client) Unregister(procedure string) error {
 		return fmt.Errorf(formatUnexpectedMessage(msg, UNREGISTERED))
 	}
 	// register the event handler with this unregistration
-	delete(c.procedures, procedureID)
+	c.acts <- func() {
+		delete(c.procedures, procedureID)
+		sync <- struct{}{}
+	}
+	<-sync
 	return nil
 }
 
 // Publish publishes an EVENT to all subscribed peers.
 func (c *Client) Publish(topic string, args []interface{}, kwargs map[string]interface{}) error {
-	return c.Send(&Publish{
-		Request:     NewID(),
-		Options:     make(map[string]interface{}),
-		Topic:       URI(topic),
-		Arguments:   args,
-		ArgumentsKw: kwargs,
-	})
+	var (
+		sync = make(chan struct{})
+		err  error
+	)
+	c.acts <- func() {
+		c.Send(&Publish{
+			Request:     NewID(),
+			Options:     make(map[string]interface{}),
+			Topic:       URI(topic),
+			Arguments:   args,
+			ArgumentsKw: kwargs,
+		})
+		sync <- struct{}{}
+	}
+	<-sync
+	return err
 }
 
 // Call calls a procedure given a URI.
@@ -495,7 +629,16 @@ func (c *Client) Call(procedure string, args []interface{}, kwargs map[string]in
 		Arguments:   args,
 		ArgumentsKw: kwargs,
 	}
-	if err := c.Send(call); err != nil {
+	var (
+		sync = make(chan struct{})
+		err  error
+	)
+	c.acts <- func() {
+		err = c.Send(call)
+		sync <- struct{}{}
+	}
+	<-sync
+	if err != nil {
 		return nil, err
 	}
 

--- a/websocket_server.go
+++ b/websocket_server.go
@@ -95,6 +95,7 @@ func (s *WebsocketServer) GetLocalClient(realm string, details map[string]interf
 	}
 	c := NewClient(peer)
 	go c.Receive()
+	go c.run()
 	return c, nil
 }
 


### PR DESCRIPTION
Fixes #118.

Avoid data races, concurrent map accesses, and concurrent writes
to websocket connections.

Instead of sprinkling locks all over the client, realm, broker,
and dealer implementations this approach uses a goroutine in each
client and realm -- processing closures serially to guarantee
exclusion between other goroutines.

Passes unit tests under Golang 1.6 with the race detector turned on.
