### PR TITLE
Restore concurrency during publishing

### DIFF
--- a/dealer.go
+++ b/dealer.go
@@ -1,5 +1,7 @@
 package turnpike
 
+import "sync"
+
 // A Dealer routes and manages RPC calls to callees.
 type Dealer interface {
 	// Register a procedure on an endpoint
@@ -34,6 +36,8 @@ type defaultDealer struct {
 	invocations map[ID]ID
 	// keep track of callee's registrations
 	callees map[Sender]map[ID]bool
+	// protect maps from concurrent access
+	lock sync.Mutex
 }
 
 // NewDefaultDealer returns the default turnpike dealer implementation
@@ -48,7 +52,10 @@ func NewDefaultDealer() Dealer {
 }
 
 func (d *defaultDealer) Register(callee Sender, msg *Register) {
+	reg := NewID()
+	d.lock.Lock()
 	if id, ok := d.registrations[msg.Procedure]; ok {
+		d.lock.Unlock()
 		log.Println("error: procedure already exists:", msg.Procedure, id)
 		callee.Send(&Error{
 			Type:    msg.MessageType(),
@@ -58,10 +65,11 @@ func (d *defaultDealer) Register(callee Sender, msg *Register) {
 		})
 		return
 	}
-	reg := NewID()
 	d.procedures[reg] = remoteProcedure{callee, msg.Procedure}
 	d.registrations[msg.Procedure] = reg
 	d.addCalleeRegistration(callee, reg)
+	d.lock.Unlock()
+
 	log.Printf("registered procedure %v [%v]", reg, msg.Procedure)
 	callee.Send(&Registered{
 		Request:      msg.Request,
@@ -70,7 +78,9 @@ func (d *defaultDealer) Register(callee Sender, msg *Register) {
 }
 
 func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
+	d.lock.Lock()
 	if procedure, ok := d.procedures[msg.Registration]; !ok {
+		d.lock.Unlock()
 		// the registration doesn't exist
 		log.Println("error: no such registration:", msg.Registration)
 		callee.Send(&Error{
@@ -83,6 +93,7 @@ func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
 		delete(d.registrations, procedure.Procedure)
 		delete(d.procedures, msg.Registration)
 		d.removeCalleeRegistration(callee, msg.Registration)
+		d.lock.Unlock()
 		log.Printf("unregistered procedure %v [%v]", procedure.Procedure, msg.Registration)
 		callee.Send(&Unregistered{
 			Request: msg.Request,
@@ -91,7 +102,9 @@ func (d *defaultDealer) Unregister(callee Sender, msg *Unregister) {
 }
 
 func (d *defaultDealer) Call(caller Sender, msg *Call) {
+	d.lock.Lock()
 	if reg, ok := d.registrations[msg.Procedure]; !ok {
+		d.lock.Unlock()
 		caller.Send(&Error{
 			Type:    msg.MessageType(),
 			Request: msg.Request,
@@ -101,6 +114,7 @@ func (d *defaultDealer) Call(caller Sender, msg *Call) {
 	} else {
 		if rproc, ok := d.procedures[reg]; !ok {
 			// found a registration id, but doesn't match any remote procedure
+			d.lock.Unlock()
 			caller.Send(&Error{
 				Type:    msg.MessageType(),
 				Request: msg.Request,
@@ -114,6 +128,7 @@ func (d *defaultDealer) Call(caller Sender, msg *Call) {
 			d.calls[msg.Request] = caller
 			invocationID := NewID()
 			d.invocations[invocationID] = msg.Request
+			d.lock.Unlock()
 			rproc.Endpoint.Send(&Invocation{
 				Request:      invocationID,
 				Registration: reg,
@@ -129,7 +144,9 @@ func (d *defaultDealer) Call(caller Sender, msg *Call) {
 }
 
 func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
+	d.lock.Lock()
 	if callID, ok := d.invocations[msg.Request]; !ok {
+		d.lock.Unlock()
 		// WAMP spec doesn't allow sending an error in response to a YIELD message
 		log.Println("received YIELD message with invalid invocation request ID:", msg.Request)
 	} else {
@@ -137,9 +154,11 @@ func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
 		if caller, ok := d.calls[callID]; !ok {
 			// found the invocation id, but doesn't match any call id
 			// WAMP spec doesn't allow sending an error in response to a YIELD message
+			d.lock.Unlock()
 			log.Printf("received YIELD message, but unable to match it (%v) to a CALL ID", msg.Request)
 		} else {
 			delete(d.calls, callID)
+			d.lock.Unlock()
 			// return the result to the caller
 			caller.Send(&Result{
 				Request:     callID,
@@ -153,14 +172,18 @@ func (d *defaultDealer) Yield(callee Sender, msg *Yield) {
 }
 
 func (d *defaultDealer) Error(peer Sender, msg *Error) {
+	d.lock.Lock()
 	if callID, ok := d.invocations[msg.Request]; !ok {
+		d.lock.Unlock()
 		log.Println("received ERROR (INVOCATION) message with invalid invocation request ID:", msg.Request)
 	} else {
 		delete(d.invocations, msg.Request)
 		if caller, ok := d.calls[callID]; !ok {
+			d.lock.Unlock()
 			log.Printf("received ERROR (INVOCATION) message, but unable to match it (%v) to a CALL ID", msg.Request)
 		} else {
 			delete(d.calls, callID)
+			d.lock.Unlock()
 			// return an error to the caller
 			caller.Send(&Error{
 				Type:        CALL,
@@ -175,6 +198,8 @@ func (d *defaultDealer) Error(peer Sender, msg *Error) {
 }
 
 func (d *defaultDealer) RemovePeer(callee Sender) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
 	for reg := range d.callees[callee] {
 		if procedure, ok := d.procedures[reg]; ok {
 			delete(d.registrations, procedure.Procedure)

--- a/realm.go
+++ b/realm.go
@@ -172,27 +172,27 @@ func (r *Realm) handleSession(sess Session) {
 
 		// Broker messages
 		case *Publish:
-			r.acts <- func() { r.Broker.Publish(sess.Peer, msg) }
+			r.Broker.Publish(sess.Peer, msg)
 		case *Subscribe:
-			r.acts <- func() { r.Broker.Subscribe(sess.Peer, msg) }
+			r.Broker.Subscribe(sess.Peer, msg)
 		case *Unsubscribe:
-			r.acts <- func() { r.Broker.Unsubscribe(sess.Peer, msg) }
+			r.Broker.Unsubscribe(sess.Peer, msg)
 
 		// Dealer messages
 		case *Register:
-			r.acts <- func() { r.Dealer.Register(sess.Peer, msg) }
+			r.Dealer.Register(sess.Peer, msg)
 		case *Unregister:
-			r.acts <- func() { r.Dealer.Unregister(sess.Peer, msg) }
+			r.Dealer.Unregister(sess.Peer, msg)
 		case *Call:
-			r.acts <- func() { r.Dealer.Call(sess.Peer, msg) }
+			r.Dealer.Call(sess.Peer, msg)
 		case *Yield:
-			r.acts <- func() { r.Dealer.Yield(sess.Peer, msg) }
+			r.Dealer.Yield(sess.Peer, msg)
 
 		// Error messages
 		case *Error:
 			if msg.Type == INVOCATION {
 				// the only type of ERROR message the router should receive
-				r.acts <- func() { r.Dealer.Error(sess.Peer, msg) }
+				r.Dealer.Error(sess.Peer, msg)
 			} else {
 				log.Printf("invalid ERROR message received: %v", msg)
 			}

--- a/websocket.go
+++ b/websocket.go
@@ -3,6 +3,7 @@ package turnpike
 import (
 	"crypto/tls"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +15,7 @@ type websocketPeer struct {
 	messages    chan Message
 	payloadType int
 	closed      bool
+	sendMutex   sync.Mutex
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
@@ -58,6 +60,8 @@ func (ep *websocketPeer) Send(msg Message) error {
 	if err != nil {
 		return err
 	}
+	ep.sendMutex.Lock()
+	defer ep.sendMutex.Unlock()
 	return ep.conn.WriteMessage(ep.payloadType, b)
 }
 func (ep *websocketPeer) Receive() <-chan Message {


### PR DESCRIPTION
Addresses post-merge feedback from @yanfali on #119.

This PR restores the ability of realm-level session handlers to publish concurrently.  Includes commit from #117.
