### PR TITLE
Allow websocket.Dialer to be passed in NewWebsocketPeer

### DIFF
--- a/client.go
+++ b/client.go
@@ -56,7 +56,7 @@ type eventDesc struct {
 // NewWebsocketClient creates a new websocket client connected to the specified
 // `url` and using the specified `serialization`.
 func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Config, dialer *websocket.Dialer) (*Client, error) {
-	p, err := NewWebsocketPeer(serialization, url, "", tlscfg, dialer)
+	p, err := NewWebsocketPeer(serialization, url, tlscfg, dialer)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"fmt"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 var (
@@ -53,8 +55,8 @@ type eventDesc struct {
 
 // NewWebsocketClient creates a new websocket client connected to the specified
 // `url` and using the specified `serialization`.
-func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Config) (*Client, error) {
-	p, err := NewWebsocketPeer(serialization, url, "", tlscfg)
+func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Config, dialer *websocket.Dialer) (*Client, error) {
+	p, err := NewWebsocketPeer(serialization, url, "", tlscfg, dialer)
 	if err != nil {
 		return nil, err
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -19,14 +19,14 @@ type websocketPeer struct {
 }
 
 // NewWebsocketPeer connects to the websocket server at the specified url.
-func NewWebsocketPeer(serialization Serialization, url, origin string, tlscfg *tls.Config, dialer *websocket.Dialer) (Peer, error) {
+func NewWebsocketPeer(serialization Serialization, url string, tlscfg *tls.Config, dialer *websocket.Dialer) (Peer, error) {
 	switch serialization {
 	case JSON:
-		return newWebsocketPeer(url, jsonWebsocketProtocol, origin,
+		return newWebsocketPeer(url, jsonWebsocketProtocol,
 			new(JSONSerializer), websocket.TextMessage, tlscfg, dialer,
 		)
 	case MSGPACK:
-		return newWebsocketPeer(url, msgpackWebsocketProtocol, origin,
+		return newWebsocketPeer(url, msgpackWebsocketProtocol,
 			new(MessagePackSerializer), websocket.BinaryMessage, tlscfg, dialer,
 		)
 	default:
@@ -34,7 +34,7 @@ func NewWebsocketPeer(serialization Serialization, url, origin string, tlscfg *t
 	}
 }
 
-func newWebsocketPeer(url, protocol, origin string, serializer Serializer, payloadType int, tlscfg *tls.Config, dialer *websocket.Dialer) (Peer, error) {
+func newWebsocketPeer(url, protocol string, serializer Serializer, payloadType int, tlscfg *tls.Config, dialer *websocket.Dialer) (Peer, error) {
 	switch dialer {
 	case nil:
 		dialer = &websocket.Dialer{

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -29,7 +29,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil)
+	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil)
+	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), "http://localhost", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I found a need to modify the `Proxy` and `NetDial` fields of `websocket.Dialer` struct.  Instead of adding each parameter to the `NewWebsocketClient(...)` function, allowing a dialer to be passed in directly, and default in case `nil` is passed in.

Also remove the unused `origin string` parameter.
