### PR TITLE
Fix empty options

### DIFF
--- a/client.go
+++ b/client.go
@@ -391,6 +391,9 @@ type EventHandler func(args []interface{}, kwargs map[string]interface{})
 
 // Subscribe registers the EventHandler to be called for every message in the provided topic.
 func (c *Client) Subscribe(topic string, options map[string]interface{}, fn EventHandler) error {
+	if options == nil {
+		options = make(map[string]interface{})
+	}
 	id := NewID()
 	c.registerListener(id)
 	sub := &Subscribe{
@@ -575,6 +578,9 @@ func (c *Client) Unregister(procedure string) error {
 
 // Publish publishes an EVENT to all subscribed peers.
 func (c *Client) Publish(topic string, options map[string]interface{}, args []interface{}, kwargs map[string]interface{}) error {
+	if options == nil {
+		options = make(map[string]interface{})
+	}
 	return c.Send(&Publish{
 		Request:     NewID(),
 		Options:     options,


### PR DESCRIPTION
Commit https://github.com/jcelliott/turnpike/commit/ea7a90fa9d58dd53f1fe49ad8234ae728267935d adds `options` argument to `Subscribe` and `Publish` methods. In all examples `nil` passed as this argument. But some servers returns errors like this:
```
'options' in SUBSCRIBE: invalid type <type 'NoneType'>
```
And don't accept empty `options` argument. This PR sets default empty options, as it was before that change.