### PR TITLE
fix the port setting line in the router main command

### DIFF
--- a/turnpike/main.go
+++ b/turnpike/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -41,7 +42,7 @@ func main() {
 
 	server := &http.Server{
 		Handler: s,
-		Addr:    ":8000",
+		Addr:    fmt.Sprintf(":%d", port),
 	}
 	log.Printf("turnpike server starting on port %d...", port)
 	log.Fatal(server.ListenAndServe())


### PR DESCRIPTION
This patch fixes the server port configuration issue in the command line application.
Currently, the port value can be configured but the value is not passed to the server's configuration. As a result, the port remains as 8000.
