### PR TITLE
Allow request headers to be passed while creating new websocket peer

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package turnpike
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -53,8 +54,8 @@ type eventDesc struct {
 
 // NewWebsocketClient creates a new websocket client connected to the specified
 // `url` and using the specified `serialization`.
-func NewWebsocketClient(serialization Serialization, url string, tlscfg *tls.Config, dial DialFunc) (*Client, error) {
-	p, err := NewWebsocketPeer(serialization, url, tlscfg, dial)
+func NewWebsocketClient(serialization Serialization, url string, requestHeader http.Header, tlscfg *tls.Config, dial DialFunc) (*Client, error) {
+	p, err := NewWebsocketPeer(serialization, url, requestHeader, tlscfg, dial)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/auth/client/client.go
+++ b/examples/auth/client/client.go
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/ws", nil, nil)
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/ws", nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/chat/chatclient/main.go
+++ b/examples/chat/chatclient/main.go
@@ -36,7 +36,7 @@ func main() {
 	username := os.Args[1]
 
 	// turnpike.Debug()
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil)
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/meta-api/meta-client.go
+++ b/examples/meta-api/meta-client.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil)
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/rpc-with-options/rpc-client/main.go
+++ b/examples/rpc-with-options/rpc-client/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	turnpike.Debug()
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil)
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/rpc/rpc-client/main.go
+++ b/examples/rpc/rpc-client/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	turnpike.Debug()
-	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil)
+	c, err := turnpike.NewWebsocketClient(turnpike.JSON, "ws://localhost:8000/", nil, nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -19,14 +19,14 @@ type websocketPeer struct {
 	sendMutex   sync.Mutex
 }
 
-func NewWebsocketPeer(serialization Serialization, url string, tlscfg *tls.Config, dial DialFunc) (Peer, error) {
+func NewWebsocketPeer(serialization Serialization, url string, requestHeader http.Header, tlscfg *tls.Config, dial DialFunc) (Peer, error) {
 	switch serialization {
 	case JSON:
-		return newWebsocketPeer(url, jsonWebsocketProtocol,
+		return newWebsocketPeer(url, requestHeader, jsonWebsocketProtocol,
 			new(JSONSerializer), websocket.TextMessage, tlscfg, dial,
 		)
 	case MSGPACK:
-		return newWebsocketPeer(url, msgpackWebsocketProtocol,
+		return newWebsocketPeer(url, requestHeader, msgpackWebsocketProtocol,
 			new(MessagePackSerializer), websocket.BinaryMessage, tlscfg, dial,
 		)
 	default:
@@ -34,14 +34,14 @@ func NewWebsocketPeer(serialization Serialization, url string, tlscfg *tls.Confi
 	}
 }
 
-func newWebsocketPeer(url, protocol string, serializer Serializer, payloadType int, tlscfg *tls.Config, dial DialFunc) (Peer, error) {
+func newWebsocketPeer(url string, reqHeader http.Header, protocol string, serializer Serializer, payloadType int, tlscfg *tls.Config, dial DialFunc) (Peer, error) {
 	dialer := websocket.Dialer{
 		Subprotocols:    []string{protocol},
 		TLSClientConfig: tlscfg,
 		Proxy:           http.ProxyFromEnvironment,
 		NetDial:         dial,
 	}
-	conn, _, err := dialer.Dial(url, nil)
+	conn, _, err := dialer.Dial(url, reqHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -29,7 +29,7 @@ func TestWSHandshakeJSON(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), nil, nil)
+	client, err := NewWebsocketPeer(JSON, fmt.Sprintf("ws://localhost:%d/", port), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestWSHandshakeMsgpack(t *testing.T) {
 	port, r, closer := newTestWebsocketServer(t)
 	defer closer.Close()
 
-	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), nil, nil)
+	client, err := NewWebsocketPeer(MSGPACK, fmt.Sprintf("ws://localhost:%d/", port), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Request headers can be used to pass application specific headers to
  WAMP connection initiation request.
- Updated examples with new client interface.