### PR TITLE
Client panics when connection is closed while `waitForListener` is waiting for message

### DIFF
--- a/vendor/github.com/jtolds/gls/context.go
+++ b/vendor/github.com/jtolds/gls/context.go
@@ -5,12 +5,7 @@ import (
 	"sync"
 )
 
-const (
-	maxCallers = 64
-)
-
 var (
-	stackTagPool   = &idPool{}
 	mgrRegistry    = make(map[*ContextManager]bool)
 	mgrRegistryMtx sync.RWMutex
 )
@@ -25,7 +20,7 @@ type Values map[interface{}]interface{}
 // class of context variables. You should use NewContextManager for
 // construction.
 type ContextManager struct {
-	mtx    sync.RWMutex
+	mtx    sync.Mutex
 	values map[uint]Values
 }
 
@@ -62,63 +57,77 @@ func (m *ContextManager) SetValues(new_values Values, context_call func()) {
 		return
 	}
 
-	tags := readStackTags(1)
+	mutated_keys := make([]interface{}, 0, len(new_values))
+	mutated_vals := make(Values, len(new_values))
 
-	m.mtx.Lock()
-	values := new_values
-	for _, tag := range tags {
-		if existing_values, ok := m.values[tag]; ok {
-			// oh, we found existing values, let's make a copy
-			values = make(Values, len(existing_values)+len(new_values))
-			for key, val := range existing_values {
-				values[key] = val
-			}
-			for key, val := range new_values {
-				values[key] = val
-			}
-			break
-		}
-	}
-	new_tag := stackTagPool.Acquire()
-	m.values[new_tag] = values
-	m.mtx.Unlock()
-	defer func() {
+	EnsureGoroutineId(func(gid uint) {
 		m.mtx.Lock()
-		delete(m.values, new_tag)
+		state, found := m.values[gid]
+		if !found {
+			state = make(Values, len(new_values))
+			m.values[gid] = state
+		}
 		m.mtx.Unlock()
-		stackTagPool.Release(new_tag)
-	}()
 
-	addStackTag(new_tag, context_call)
+		for key, new_val := range new_values {
+			mutated_keys = append(mutated_keys, key)
+			if old_val, ok := state[key]; ok {
+				mutated_vals[key] = old_val
+			}
+			state[key] = new_val
+		}
+
+		defer func() {
+			if !found {
+				m.mtx.Lock()
+				delete(m.values, gid)
+				m.mtx.Unlock()
+				return
+			}
+
+			for _, key := range mutated_keys {
+				if val, ok := mutated_vals[key]; ok {
+					state[key] = val
+				} else {
+					delete(state, key)
+				}
+			}
+		}()
+
+		context_call()
+	})
 }
 
 // GetValue will return a previously set value, provided that the value was set
 // by SetValues somewhere higher up the stack. If the value is not found, ok
 // will be false.
-func (m *ContextManager) GetValue(key interface{}) (value interface{}, ok bool) {
-
-	tags := readStackTags(1)
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-	for _, tag := range tags {
-		if values, ok := m.values[tag]; ok {
-			value, ok := values[key]
-			return value, ok
-		}
+func (m *ContextManager) GetValue(key interface{}) (
+	value interface{}, ok bool) {
+	gid, ok := GetGoroutineId()
+	if !ok {
+		return nil, false
 	}
-	return "", false
+
+	m.mtx.Lock()
+	state, found := m.values[gid]
+	m.mtx.Unlock()
+
+	if !found {
+		return nil, false
+	}
+	value, ok = state[key]
+	return value, ok
 }
 
 func (m *ContextManager) getValues() Values {
-	tags := readStackTags(2)
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-	for _, tag := range tags {
-		if values, ok := m.values[tag]; ok {
-			return values
-		}
+	gid, ok := GetGoroutineId()
+	if !ok {
+		return nil
 	}
-	return nil
+	m.mtx.Lock()
+	state, _ := m.values[gid]
+	m.mtx.Unlock()
+	return state
 }
 
 // Go preserves ContextManager values and Goroutine-local-storage across new
@@ -131,12 +140,12 @@ func Go(cb func()) {
 	mgrRegistryMtx.RLock()
 	defer mgrRegistryMtx.RUnlock()
 
-	for mgr, _ := range mgrRegistry {
+	for mgr := range mgrRegistry {
 		values := mgr.getValues()
 		if len(values) > 0 {
-			mgr_copy := mgr
-			cb_copy := cb
-			cb = func() { mgr_copy.SetValues(values, cb_copy) }
+			cb = func(mgr *ContextManager, cb func()) func() {
+				return func() { mgr.SetValues(values, cb) }
+			}(mgr, cb)
 		}
 	}
 

--- a/vendor/github.com/jtolds/gls/gen_sym.go
+++ b/vendor/github.com/jtolds/gls/gen_sym.go
@@ -1,13 +1,21 @@
 package gls
 
+import (
+	"sync"
+)
+
 var (
-	symPool = &idPool{}
+	keyMtx     sync.Mutex
+	keyCounter uint64
 )
 
 // ContextKey is a throwaway value you can use as a key to a ContextManager
-type ContextKey struct{ id uint }
+type ContextKey struct{ id uint64 }
 
 // GenSym will return a brand new, never-before-used ContextKey
 func GenSym() ContextKey {
-	return ContextKey{id: symPool.Acquire()}
+	keyMtx.Lock()
+	defer keyMtx.Unlock()
+	keyCounter += 1
+	return ContextKey{id: keyCounter}
 }

--- a/vendor/github.com/jtolds/gls/gid.go
+++ b/vendor/github.com/jtolds/gls/gid.go
@@ -1,0 +1,25 @@
+package gls
+
+var (
+	stackTagPool = &idPool{}
+)
+
+// Will return this goroutine's identifier if set. If you always need a
+// goroutine identifier, you should use EnsureGoroutineId which will make one
+// if there isn't one already.
+func GetGoroutineId() (gid uint, ok bool) {
+	return readStackTag()
+}
+
+// Will call cb with the current goroutine identifier. If one hasn't already
+// been generated, one will be created and set first. The goroutine identifier
+// might be invalid after cb returns.
+func EnsureGoroutineId(cb func(gid uint)) {
+	if gid, ok := readStackTag(); ok {
+		cb(gid)
+		return
+	}
+	gid := stackTagPool.Acquire()
+	defer stackTagPool.Release(gid)
+	addStackTag(gid, func() { cb(gid) })
+}

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -3,36 +3,105 @@ package gls
 // so, basically, we're going to encode integer tags in base-16 on the stack
 
 const (
-	bitWidth = 4
+	bitWidth       = 4
+	stackBatchSize = 16
 )
+
+var (
+	pc_lookup   = make(map[uintptr]int8, 17)
+	mark_lookup [16]func(uint, func())
+)
+
+func init() {
+	setEntries := func(f func(uint, func()), v int8) {
+		var ptr uintptr
+		f(0, func() {
+			ptr = findPtr()
+		})
+		pc_lookup[ptr] = v
+		if v >= 0 {
+			mark_lookup[v] = f
+		}
+	}
+	setEntries(github_com_jtolds_gls_markS, -0x1)
+	setEntries(github_com_jtolds_gls_mark0, 0x0)
+	setEntries(github_com_jtolds_gls_mark1, 0x1)
+	setEntries(github_com_jtolds_gls_mark2, 0x2)
+	setEntries(github_com_jtolds_gls_mark3, 0x3)
+	setEntries(github_com_jtolds_gls_mark4, 0x4)
+	setEntries(github_com_jtolds_gls_mark5, 0x5)
+	setEntries(github_com_jtolds_gls_mark6, 0x6)
+	setEntries(github_com_jtolds_gls_mark7, 0x7)
+	setEntries(github_com_jtolds_gls_mark8, 0x8)
+	setEntries(github_com_jtolds_gls_mark9, 0x9)
+	setEntries(github_com_jtolds_gls_markA, 0xa)
+	setEntries(github_com_jtolds_gls_markB, 0xb)
+	setEntries(github_com_jtolds_gls_markC, 0xc)
+	setEntries(github_com_jtolds_gls_markD, 0xd)
+	setEntries(github_com_jtolds_gls_markE, 0xe)
+	setEntries(github_com_jtolds_gls_markF, 0xf)
+}
 
 func addStackTag(tag uint, context_call func()) {
 	if context_call == nil {
 		return
 	}
-	markS(tag, context_call)
+	github_com_jtolds_gls_markS(tag, context_call)
 }
 
-func markS(tag uint, cb func()) { _m(tag, cb) }
-func mark0(tag uint, cb func()) { _m(tag, cb) }
-func mark1(tag uint, cb func()) { _m(tag, cb) }
-func mark2(tag uint, cb func()) { _m(tag, cb) }
-func mark3(tag uint, cb func()) { _m(tag, cb) }
-func mark4(tag uint, cb func()) { _m(tag, cb) }
-func mark5(tag uint, cb func()) { _m(tag, cb) }
-func mark6(tag uint, cb func()) { _m(tag, cb) }
-func mark7(tag uint, cb func()) { _m(tag, cb) }
-func mark8(tag uint, cb func()) { _m(tag, cb) }
-func mark9(tag uint, cb func()) { _m(tag, cb) }
-func markA(tag uint, cb func()) { _m(tag, cb) }
-func markB(tag uint, cb func()) { _m(tag, cb) }
-func markC(tag uint, cb func()) { _m(tag, cb) }
-func markD(tag uint, cb func()) { _m(tag, cb) }
-func markE(tag uint, cb func()) { _m(tag, cb) }
-func markF(tag uint, cb func()) { _m(tag, cb) }
+// these private methods are named this horrendous name so gopherjs support
+// is easier. it shouldn't add any runtime cost in non-js builds.
 
-var pc_lookup = make(map[uintptr]int8, 17)
-var mark_lookup [16]func(uint, func())
+//go:noinline
+func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
+func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
 
 func _m(tag_remainder uint, cb func()) {
 	if tag_remainder == 0 {
@@ -40,4 +109,39 @@ func _m(tag_remainder uint, cb func()) {
 	} else {
 		mark_lookup[tag_remainder&0xf](tag_remainder>>bitWidth, cb)
 	}
+}
+
+func readStackTag() (tag uint, ok bool) {
+	var current_tag uint
+	offset := 0
+	for {
+		batch, next_offset := getStack(offset, stackBatchSize)
+		for _, pc := range batch {
+			val, ok := pc_lookup[pc]
+			if !ok {
+				continue
+			}
+			if val < 0 {
+				return current_tag, true
+			}
+			current_tag <<= bitWidth
+			current_tag += uint(val)
+		}
+		if next_offset == 0 {
+			break
+		}
+		offset = next_offset
+	}
+	return 0, false
+}
+
+func (m *ContextManager) preventInlining() {
+	// dunno if findPtr or getStack are likely to get inlined in a future release
+	// of go, but if they are inlined and their callers are inlined, that could
+	// hork some things. let's do our best to explain to the compiler that we
+	// really don't want those two functions inlined by saying they could change
+	// at any time. assumes preventInlining doesn't get compiled out.
+	// this whole thing is probably overkill.
+	findPtr = m.values[0][0].(func() uintptr)
+	getStack = m.values[0][1].(func(int, int) ([]uintptr, int))
 }

--- a/vendor/github.com/jtolds/gls/stack_tags_js.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_js.go
@@ -2,100 +2,74 @@
 
 package gls
 
-// This file is used for GopherJS builds, which don't have normal runtime support
+// This file is used for GopherJS builds, which don't have normal runtime
+// stack trace support
 
 import (
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/gopherjs/gopherjs/js"
 )
 
-var stackRE = regexp.MustCompile("\\s+at (\\S*) \\([^:]+:(\\d+):(\\d+)")
+const (
+	jsFuncNamePrefix = "github_com_jtolds_gls_mark"
+)
 
-func findPtr() uintptr {
-	jsStack := js.Global.Get("Error").New().Get("stack").Call("split", "\n")
-	for i := 1; i < jsStack.Get("length").Int(); i++ {
-		item := jsStack.Index(i).String()
-		matches := stackRE.FindAllStringSubmatch(item, -1)
-		if matches == nil {
-			return 0
-		}
-		pkgPath := matches[0][1]
-		if strings.HasPrefix(pkgPath, "$packages.github.com/jtolds/gls.mark") {
-			line, _ := strconv.Atoi(matches[0][2])
-			char, _ := strconv.Atoi(matches[0][3])
-			x := (uintptr(line) << 16) | uintptr(char)
-			return x
-		}
-	}
-
-	return 0
-}
-
-func init() {
-	setEntries := func(f func(uint, func()), v int8) {
-		var ptr uintptr
-		f(0, func() {
-			ptr = findPtr()
-		})
-		pc_lookup[ptr] = v
-		if v >= 0 {
-			mark_lookup[v] = f
-		}
-	}
-	setEntries(markS, -0x1)
-	setEntries(mark0, 0x0)
-	setEntries(mark1, 0x1)
-	setEntries(mark2, 0x2)
-	setEntries(mark3, 0x3)
-	setEntries(mark4, 0x4)
-	setEntries(mark5, 0x5)
-	setEntries(mark6, 0x6)
-	setEntries(mark7, 0x7)
-	setEntries(mark8, 0x8)
-	setEntries(mark9, 0x9)
-	setEntries(markA, 0xa)
-	setEntries(markB, 0xb)
-	setEntries(markC, 0xc)
-	setEntries(markD, 0xd)
-	setEntries(markE, 0xe)
-	setEntries(markF, 0xf)
-}
-
-func currentStack(skip int) (stack []uintptr) {
-	jsStack := js.Global.Get("Error").New().Get("stack").Call("split", "\n")
-	for i := skip + 2; i < jsStack.Get("length").Int(); i++ {
-		item := jsStack.Index(i).String()
-		matches := stackRE.FindAllStringSubmatch(item, -1)
-		if matches == nil {
-			return stack
-		}
-		line, _ := strconv.Atoi(matches[0][2])
-		char, _ := strconv.Atoi(matches[0][3])
-		x := (uintptr(line) << 16) | uintptr(char)&0xffff
-		stack = append(stack, x)
-	}
-
-	return stack
-}
-
-func readStackTags(skip int) (tags []uint) {
-	stack := currentStack(skip)
-	var current_tag uint
-	for _, pc := range stack {
-		val, ok := pc_lookup[pc]
-		if !ok {
+func jsMarkStack() (f []uintptr) {
+	lines := strings.Split(
+		js.Global.Get("Error").New().Get("stack").String(), "\n")
+	f = make([]uintptr, 0, len(lines))
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
 			continue
 		}
-		if val < 0 {
-			tags = append(tags, current_tag)
-			current_tag = 0
+		if i == 0 {
+			if line != "Error" {
+				panic("didn't understand js stack trace")
+			}
 			continue
 		}
-		current_tag <<= bitWidth
-		current_tag += uint(val)
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "at" {
+			panic("didn't understand js stack trace")
+		}
+
+		pos := strings.Index(fields[1], jsFuncNamePrefix)
+		if pos < 0 {
+			continue
+		}
+		pos += len(jsFuncNamePrefix)
+		if pos >= len(fields[1]) {
+			panic("didn't understand js stack trace")
+		}
+		char := string(fields[1][pos])
+		switch char {
+		case "S":
+			f = append(f, uintptr(0))
+		default:
+			val, err := strconv.ParseUint(char, 16, 8)
+			if err != nil {
+				panic("didn't understand js stack trace")
+			}
+			f = append(f, uintptr(val)+1)
+		}
 	}
-	return
+	return f
 }
+
+// variables to prevent inlining
+var (
+	findPtr = func() uintptr {
+		funcs := jsMarkStack()
+		if len(funcs) == 0 {
+			panic("failed to find function pointer")
+		}
+		return funcs[0]
+	}
+
+	getStack = func(offset, amount int) (stack []uintptr, next_offset int) {
+		return jsMarkStack(), 0
+	}
+)

--- a/vendor/github.com/jtolds/gls/stack_tags_main.go
+++ b/vendor/github.com/jtolds/gls/stack_tags_main.go
@@ -2,60 +2,29 @@
 
 package gls
 
-// This file is used for standard Go builds, which have the expected runtime support
+// This file is used for standard Go builds, which have the expected runtime
+// support
 
 import (
-	"reflect"
 	"runtime"
 )
 
-func init() {
-	setEntries := func(f func(uint, func()), v int8) {
-		pc_lookup[reflect.ValueOf(f).Pointer()] = v
-		if v >= 0 {
-			mark_lookup[v] = f
+var (
+	findPtr = func() uintptr {
+		var pc [1]uintptr
+		n := runtime.Callers(4, pc[:])
+		if n != 1 {
+			panic("failed to find function pointer")
 		}
+		return pc[0]
 	}
-	setEntries(markS, -0x1)
-	setEntries(mark0, 0x0)
-	setEntries(mark1, 0x1)
-	setEntries(mark2, 0x2)
-	setEntries(mark3, 0x3)
-	setEntries(mark4, 0x4)
-	setEntries(mark5, 0x5)
-	setEntries(mark6, 0x6)
-	setEntries(mark7, 0x7)
-	setEntries(mark8, 0x8)
-	setEntries(mark9, 0x9)
-	setEntries(markA, 0xa)
-	setEntries(markB, 0xb)
-	setEntries(markC, 0xc)
-	setEntries(markD, 0xd)
-	setEntries(markE, 0xe)
-	setEntries(markF, 0xf)
-}
 
-func currentStack(skip int) []uintptr {
-	stack := make([]uintptr, maxCallers)
-	return stack[:runtime.Callers(3+skip, stack)]
-}
-
-func readStackTags(skip int) (tags []uint) {
-	stack := currentStack(skip)
-	var current_tag uint
-	for _, pc := range stack {
-		pc = runtime.FuncForPC(pc).Entry()
-		val, ok := pc_lookup[pc]
-		if !ok {
-			continue
+	getStack = func(offset, amount int) (stack []uintptr, next_offset int) {
+		stack = make([]uintptr, amount)
+		stack = stack[:runtime.Callers(offset, stack)]
+		if len(stack) < amount {
+			return stack, 0
 		}
-		if val < 0 {
-			tags = append(tags, current_tag)
-			current_tag = 0
-			continue
-		}
-		current_tag <<= bitWidth
-		current_tag += uint(val)
+		return stack, offset + len(stack)
 	}
-	return
-}
+)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,10 +21,10 @@
 			"revisionTime": "2016-10-03T13:09:00Z"
 		},
 		{
-			"checksumSHA1": "tewA7jXVGCw1zb5mA0BDecWi4iQ=",
+			"checksumSHA1": "cIiyvAduLLFvu+tg1Qr5Jw3jeWo=",
 			"path": "github.com/jtolds/gls",
-			"revision": "8ddce2a84170772b95dd5d576c48d517b22cac63",
-			"revisionTime": "2016-01-05T22:08:40Z"
+			"revision": "b4936e06046bbecbb94cae9c18127ebe510a2cb9",
+			"revisionTime": "2018-11-10T20:28:10Z"
 		},
 		{
 			"checksumSHA1": "S31nRlUmg3MIVUTaLPjrjCnUYvQ=",


### PR DESCRIPTION
Encountered a panic in the client when a subscribe message is sent and the connection is immediately closed (logs included below). 
The `waitForListener` function will eventually timeout but when it does an attempt to write to the `acts` channel which has already closed produces the panic. The fix is to close all listener channels before exiting main `run()` loop which allows `waitForListener` to determine the listener channel has closed and return w/o writing `acts`.


NOTE: Also includes `govendor update github.com/jtolds/gls` as unit tests panic w/o this (using go 1.14)

```
time="2021-06-28T15:32:39Z" level=debug msg=close realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:32:42Z" level=error msg="websocket: bad handshake" realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:32:59Z" level=debug msg=open realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:32:59Z" level=info msg=connected realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:33:09Z" level=error msg="timeout while waiting for message" realm=test router="{ws   1.1.1.1 /api/ws  false  }" topic=orion.admin.user.events.v1
time="2021-06-28T15:33:09Z" level=debug msg=close realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:33:10Z" level=debug msg=open realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:33:10Z" level=info msg=connected realm=test router="{ws   1.1.1.1 /api/ws  false  }"
time="2021-06-28T15:33:20Z" level=debug msg=close realm=test router="{ws   1.1.1.1 /api/ws  false  }"
panic: send on closed channel
```

